### PR TITLE
Logic changes so that all items can, in principle, be placed in their vanilla locations

### DIFF
--- a/maps/graph_edges/edges_mac.py
+++ b/maps/graph_edges/edges_mac.py
@@ -44,7 +44,7 @@ edges_mac = [
     {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoE"},       "reqs": [require(starspirits=5)]}, #* Gate District Exit Left -> Dojo Fight E (Diploma)
     {"from": {"map": "MAC_00", "id": "DojoE"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight E (Diploma) -> Gate District Exit Left
 
-    {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 0}, "reqs": [require(item="MysteryNote"), require(item="Dictionary")], "pseudoitems": ["RF_CanSolveColorPuzzle"]}, #+ Decipher MysteryNote
+    {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 0}, "reqs": [], "pseudoitems": ["RF_CanVisitRussT"]}, #+ Can decipher MysteryNote
 
     # MAC_01 Plaza District
     {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_00", "id": 1}, "reqs": []}, # Plaza District Exit Left -> Gate District Exit Right
@@ -187,7 +187,7 @@ edges_mac = [
     {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 2}, "reqs": [require(partner="Bow",flag="RF_ToyboxOpen")]}, #? Residental District Exit Right -> Residental District Toybox Spring    
     {"from": {"map": "MAC_04", "id": 2}, "to": {"map": "MAC_04", "id": 0}, "reqs": []}, #? Residental District Toybox Spring -> Residental District Exit Right
 
-    {"from": {"map": "MAC_04", "id": 2}, "to": {"map": "MAC_04", "id": 2}, "reqs": [require(item="ToyTrain")], "pseudoitems": ["MF_Ch4_ReturnedToyTrain"]}, #+ Toybox: Throw in ToyTrain
+    {"from": {"map": "MAC_04", "id": 2}, "to": {"map": "MAC_04", "id": 2}, "reqs": [], "pseudoitems": ["MF_Ch4_CanThrowInTrain"]}, #+ Toybox: Can throw in ToyTrain
     
     {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemA"},     "reqs": [require(item="StoreroomKey")]}, #* Residental District Exit Right -> ItemA (SnowmanDoll)
     {"from": {"map": "MAC_04", "id": "ItemA"},     "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ItemA (SnowmanDoll) -> Residental District Exit Right

--- a/maps/graph_edges/edges_omo.py
+++ b/maps/graph_edges/edges_omo.py
@@ -110,7 +110,7 @@ edges_omo = [
     {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockB (SuperSoda)
     {"from": {"map": "OMO_05", "id": "HiddenYBlockB"}, "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* HiddenYBlockB (SuperSoda) -> PNK Gourmet Guy Crossing Exit East (North)
 
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item="Cake")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(flag="RF_CanVisitTayceT"),require(item="CakeMix")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
 
     # OMO_06 PNK Station
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_17", "id": 2}, "reqs": []}, # PNK Station Exit West -> PNK Tracks Hallway Exit East (South)

--- a/maps/graph_edges/edges_omo.py
+++ b/maps/graph_edges/edges_omo.py
@@ -110,8 +110,7 @@ edges_omo = [
     {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockB (SuperSoda)
     {"from": {"map": "OMO_05", "id": "HiddenYBlockB"}, "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* HiddenYBlockB (SuperSoda) -> PNK Gourmet Guy Crossing Exit East (North)
 
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item="Cake")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item="CakeMix"),require(flag="RF_CanVisitTayceT")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item=["Cake","CakeMix"]), require(flag="RF_CanVisitTayceT",item="Cake")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
 
     # OMO_06 PNK Station
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_17", "id": 2}, "reqs": []}, # PNK Station Exit West -> PNK Tracks Hallway Exit East (South)

--- a/maps/graph_edges/edges_omo.py
+++ b/maps/graph_edges/edges_omo.py
@@ -48,9 +48,9 @@ edges_omo = [
     {"from": {"map": "OMO_03", "id": 0}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Exit West -> BLU Station Spring to Toad Town
     {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 1}, "reqs": []}, #? BLU Station Spring to Toad Town -> BLU Station Exit East
     {"from": {"map": "OMO_03", "id": 1}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Exit East -> BLU Station Spring to Toad Town
-    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 2}, "reqs": [require(flag="MF_Ch4_ReturnedToyTrain"),require(flag="RF_BlueSwitchPulled")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train West
+    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 2}, "reqs": [require(flag="MF_Ch4_CanThrowInTrain"),require(item="ToyTrain"),require(flag="RF_BlueSwitchPulled")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train West
     {"from": {"map": "OMO_03", "id": 2}, "to": {"map": "OMO_03", "id": 4}, "reqs": [], "pseudoitems": ["RF_BlueSwitchPulled"]}, #? BLU Station Ride Train West -> BLU Station Spring to Toad Town
-    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 3}, "reqs": [require(flag="MF_Ch4_ReturnedToyTrain")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train East
+    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 3}, "reqs": [require(flag="MF_Ch4_CanThrowInTrain"),require(item="ToyTrain")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train East
     {"from": {"map": "OMO_03", "id": 3}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Ride Train East -> BLU Station Spring to Toad Town
     
     {"from": {"map": "OMO_03", "id": 4},               "to": {"map": "OMO_03", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* BLU Station Spring to Toad Town -> HiddenPanel (StarPiece)
@@ -110,7 +110,8 @@ edges_omo = [
     {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockB (SuperSoda)
     {"from": {"map": "OMO_05", "id": "HiddenYBlockB"}, "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* HiddenYBlockB (SuperSoda) -> PNK Gourmet Guy Crossing Exit East (North)
 
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(flag="RF_CanVisitTayceT"),require(item="CakeMix")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item="Cake")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item="CakeMix"),require(flag="RF_CanVisitTayceT")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
 
     # OMO_06 PNK Station
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_17", "id": 2}, "reqs": []}, # PNK Station Exit West -> PNK Tracks Hallway Exit East (South)
@@ -164,7 +165,7 @@ edges_omo = [
     {"from": {"map": "OMO_08", "id": 0},               "to": {"map": "OMO_08", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* GRN Station Exit East -> HiddenYBlockA (FireFlower)
     {"from": {"map": "OMO_08", "id": "HiddenYBlockA"}, "to": {"map": "OMO_08", "id": 0},               "reqs": []}, #* HiddenYBlockA (FireFlower) -> GRN Station Exit East
 
-    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": [require(flag="RF_CanSolveColorPuzzle"),require(hammer=1)], "pseudoitems": ["MF_Ch4_SolvedColorPuzzle"]}, #+ Solve Color Puzzle
+    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": [require(flag="RF_CanVisitRussT"),require(item="MysteryNote"),require(item="Dictionary"),require(hammer=1)], "pseudoitems": ["MF_Ch4_SolvedColorPuzzle"]}, #+ Solve Color Puzzle
 
     # OMO_09 GRN Treadmills/Slot Machine
     {"from": {"map": "OMO_09", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": []}, # GRN Treadmills/Slot Machine Exit West -> GRN Station Exit East

--- a/metadata/itemlocation_special.py
+++ b/metadata/itemlocation_special.py
@@ -107,12 +107,13 @@ limited_by_item_areas = {
     # Chapter 4 Shy Guy's Toybox
     "OMO": {
         "keys": [
+            "StoreroomKey",
             "ToyTrain",
             "Dictionary",
             "MysteryNote"
         ],
         "misc": [
-            "Cake",
+            "CakeMix",
         ]
     },
     # Chapter 5 Mt. Lavalava
@@ -122,6 +123,8 @@ limited_by_item_areas = {
             "MagicalBean",
             "FertileSoil",
             "MiracleWater",
+            "CrystalBerry",
+            "WaterStone",
         ],
         "misc": [
             "BubbleBerry",

--- a/metadata/itemlocation_special.py
+++ b/metadata/itemlocation_special.py
@@ -107,13 +107,12 @@ limited_by_item_areas = {
     # Chapter 4 Shy Guy's Toybox
     "OMO": {
         "keys": [
-            "StoreroomKey",
             "ToyTrain",
             "Dictionary",
             "MysteryNote"
         ],
         "misc": [
-            "CakeMix",
+            "Cake",
         ]
     },
     # Chapter 5 Mt. Lavalava

--- a/metadata/progression_items.py
+++ b/metadata/progression_items.py
@@ -26,6 +26,7 @@ progression_items = {
     0x0024 : "Dictionary",
     0x0025 : "MysteryNote",
     0x0027 : "CrystalBall",
+    0x0029 : "Cookbook",
     0x002A : "JadeRaven",
     0x002B : "MagicalSeed1",
     0x002C : "MagicalSeed2",
@@ -125,5 +126,5 @@ progression_miscitems = [
     "DriedPasta",  # 0x00A7 (Koopa Koot: +KoopaLeaf -> Koopasta from Tayce T.)
     "CakeMix",     # 0x00AA (Koopa Koot: +KoopaLeaf -> KookyCookie; LemonCandy for AntiGuy; Cake for Gourmet Guy)
     "Coconut",     # 0x00AC (Koopa Koot)
-    #"Cake",        # 0x00C1 (Gourmet Guy) # Ignore in logic and require Cake Mix instead
+    "Cake",        # 0x00C1 (Gourmet Guy)
 ]

--- a/metadata/progression_items.py
+++ b/metadata/progression_items.py
@@ -123,7 +123,7 @@ progression_miscitems = [
     "Goomnut",     # 0x00A5 (Koopa Koot: NuttyCake from Tayce T.)
     "KoopaLeaf",   # 0x00A6 (Koopa Koot: KoopaTea from Tayce T.)
     "DriedPasta",  # 0x00A7 (Koopa Koot: +KoopaLeaf -> Koopasta from Tayce T.)
-    "CakeMix",     # 0x00AA (Koopa Koot: +KoopaLeaf -> KookyCookie from Tayce T.)
+    "CakeMix",     # 0x00AA (Koopa Koot: +KoopaLeaf -> KookyCookie; LemonCandy for AntiGuy; Cake for Gourmet Guy)
     "Coconut",     # 0x00AC (Koopa Koot)
-    "Cake",        # 0x00C1 (Gourmet Guy)
+    #"Cake",        # 0x00C1 (Gourmet Guy) # Ignore in logic and require Cake Mix instead
 ]

--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -572,7 +572,7 @@ def _get_limit_items_to_dungeons(
 
         # Reset Mario's inventory
         if partners_in_default_locations:
-            almost_all_partners = [x for x in all_partners if x != exclude_starting_partners.get(area_name)]
+            almost_all_partners = [x for x in all_partners if x != exclude_starting_partners.get(area_name) or x in starting_partners]
             _init_mario_inventory(
                 almost_all_partners,
                 starting_items,
@@ -645,7 +645,7 @@ def _get_limit_items_to_dungeons(
                 cur_items_overwritten = []
                 # Reset Mario's inventory
                 if partners_in_default_locations:
-                    almost_all_partners = [x for x in all_partners if x != exclude_starting_partners.get(area_name)]
+                    almost_all_partners = [x for x in all_partners if x != exclude_starting_partners.get(area_name) or x in starting_partners]
                     _init_mario_inventory(
                         almost_all_partners,
                         starting_items,

--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -350,50 +350,6 @@ def _get_limit_items_to_dungeons(
                 "reqs": []
             }
         ],
-        "OMO": [
-            # BLU Station Spring to Toad Town
-            # -> ItemA (SnowmanDoll)
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "MAC_04", "id": "ItemA"},
-                "reqs": [require(item="StoreroomKey")]
-            },
-            # BLU Station Spring to Toad Town
-            # -> ItemB (VoltShroom)
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "MAC_04", "id": "ItemB"},
-                "reqs": [require(item="StoreroomKey")]
-            },
-            # BLU Station Spring to Toad Town
-            # -> ItemC (ToyTrain)
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "MAC_04", "id": "ItemC"},
-                "reqs": [require(item="StoreroomKey")]
-            },
-            # BLU Station Spring to Toad Town
-            # -> ItemD (DizzyDial)
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "MAC_04", "id": "ItemD"},
-                "reqs": [require(item="StoreroomKey")]
-            },
-            # Toybox: Throw in ToyTrain
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "OMO_03", "id": 4},
-                "reqs": [require(item="ToyTrain")],
-                "pseudoitems": ["MF_Ch4_ReturnedToyTrain"],
-            },
-            # Decipher MysteryNote
-            {
-                "from": {"map": "OMO_03", "id": 4},
-                "to":   {"map": "OMO_03", "id": 4},
-                "reqs": [require(item="MysteryNote"), require(item="Dictionary")],
-                "pseudoitems": ["RF_CanSolveColorPuzzle"],
-            },
-        ],
     }
 
     remove_edges = {
@@ -489,10 +445,10 @@ def _get_limit_items_to_dungeons(
     }
 
     additional_starting_items = {
-        "DGB": ["EQUIPMENT_Boots_Progressive_2"], # Assume basement chest is reachable
-        "OMO": ["RF_CanVisitTayceT"], # Assume we can cook Cake and Lemon Candy
-        "FLO": ["EQUIPMENT_Boots_Progressive_2"], # Assume cloud machine can be reached
-        "PRA": ["EQUIPMENT_Boots_Progressive_2"], # Assume spin jump can be used to progress
+        "DGB": ["EQUIPMENT_Boots_Progressive_2"],
+        "OMO": ["MF_Ch4_CanThrowInTrain", "RF_CanVisitTayceT", "RF_CanVisitRussT"],
+        "FLO": ["EQUIPMENT_Boots_Progressive_2"],
+        "PRA": ["EQUIPMENT_Boots_Progressive_2"],
     }
 
     all_partners = all_partners_imp.copy()
@@ -509,10 +465,7 @@ def _get_limit_items_to_dungeons(
 
     for area_name in areas_to_limit:
         # Build small world graph only encompassing the current area
-        if area_name == "OMO":
-            area_nodes = get_area_nodes("OMO") + get_area_nodes("MAC")
-        else:
-            area_nodes = get_area_nodes(area_name)
+        area_nodes = get_area_nodes(area_name)
         area_edges = get_area_edges(area_name)
         if area_name in additional_edges:
             area_edges.extend(additional_edges.get(area_name))

--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -548,8 +548,7 @@ def _get_limit_items_to_dungeons(
                 False
             )
         if area_name in additional_starting_items:
-            for item in additional_starting_items[area_name]:
-                add_to_inventory(item)
+            add_to_inventory(additional_starting_items[area_name])
 
         # Find initially reachable nodes
         pool_misc_progression_items,    \

--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -350,6 +350,50 @@ def _get_limit_items_to_dungeons(
                 "reqs": []
             }
         ],
+        "OMO": [
+            # BLU Station Spring to Toad Town
+            # -> ItemA (SnowmanDoll)
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "MAC_04", "id": "ItemA"},
+                "reqs": [require(item="StoreroomKey")]
+            },
+            # BLU Station Spring to Toad Town
+            # -> ItemB (VoltShroom)
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "MAC_04", "id": "ItemB"},
+                "reqs": [require(item="StoreroomKey")]
+            },
+            # BLU Station Spring to Toad Town
+            # -> ItemC (ToyTrain)
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "MAC_04", "id": "ItemC"},
+                "reqs": [require(item="StoreroomKey")]
+            },
+            # BLU Station Spring to Toad Town
+            # -> ItemD (DizzyDial)
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "MAC_04", "id": "ItemD"},
+                "reqs": [require(item="StoreroomKey")]
+            },
+            # Toybox: Throw in ToyTrain
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "OMO_03", "id": 4},
+                "reqs": [require(item="ToyTrain")],
+                "pseudoitems": ["MF_Ch4_ReturnedToyTrain"],
+            },
+            # Decipher MysteryNote
+            {
+                "from": {"map": "OMO_03", "id": 4},
+                "to":   {"map": "OMO_03", "id": 4},
+                "reqs": [require(item="MysteryNote"), require(item="Dictionary")],
+                "pseudoitems": ["RF_CanSolveColorPuzzle"],
+            },
+        ],
     }
 
     remove_edges = {
@@ -444,6 +488,13 @@ def _get_limit_items_to_dungeons(
         "KPA": "KPA_60/4",
     }
 
+    additional_starting_items = {
+        "DGB": ["EQUIPMENT_Boots_Progressive_2"], # Assume basement chest is reachable
+        "OMO": ["RF_CanVisitTayceT"], # Assume we can cook Cake and Lemon Candy
+        "FLO": ["EQUIPMENT_Boots_Progressive_2"], # Assume cloud machine can be reached
+        "PRA": ["EQUIPMENT_Boots_Progressive_2"], # Assume spin jump can be used to progress
+    }
+
     all_partners = all_partners_imp.copy()
 
     # If partners are forced into their default locations, then we have to
@@ -458,7 +509,10 @@ def _get_limit_items_to_dungeons(
 
     for area_name in areas_to_limit:
         # Build small world graph only encompassing the current area
-        area_nodes = get_area_nodes(area_name)
+        if area_name == "OMO":
+            area_nodes = get_area_nodes("OMO") + get_area_nodes("MAC")
+        else:
+            area_nodes = get_area_nodes(area_name)
         area_edges = get_area_edges(area_name)
         if area_name in additional_edges:
             area_edges.extend(additional_edges.get(area_name))
@@ -540,10 +594,9 @@ def _get_limit_items_to_dungeons(
                 False,
                 False
             )
-        add_to_inventory([
-            "CrystalBerry",
-            "WaterStone"
-        ])
+        if area_name in additional_starting_items:
+            for item in additional_starting_items[area_name]:
+                add_to_inventory(item)
 
         # Find initially reachable nodes
         pool_misc_progression_items,    \
@@ -617,6 +670,20 @@ def _get_limit_items_to_dungeons(
 
         items_placed.extend(cur_items_placed)
         items_overwritten.extend(cur_items_overwritten)
+
+        area_goals = {
+            "TRD": [require(starspirits=1)],
+            "ISK": [require(starspirits=1)],
+            "DGB": [require(item="MysticalKey")],
+            "OMO": [require(starspirits=1)],
+            "KZN": [require(starspirits=1)],
+            "FLO": [require(starspirits=1)],
+            "PRA": [require(starspirits=1)],
+            "KPA": [lambda: "KPA_121/1" in reachable_node_ids_try],
+        }
+
+        for area_goal in area_goals[area_name]:
+            assert area_goal()
 
     all_item_node_ids = [get_node_identifier(node) for node in all_item_nodes]
     modified_nodes = [node for node in limited_filled_item_nodes if get_node_identifier(node) not in all_item_node_ids]

--- a/rando_modules/simulate.py
+++ b/rando_modules/simulate.py
@@ -192,19 +192,22 @@ def require(**kwargs):
             if partner in mario.partners:
                 return True
         # Items
-        if item := kwargs.get("item"):
-            if item in multiuse_progression_items:
-                have_any_req_item = True in (multi_item in mario.items
-                                             for multi_item in multiuse_progression_items.get(item))
-                if have_any_req_item:
-                    # remove single multiuse item #TODO very janky, pls rework
-                    for multi_item in multiuse_progression_items.get(item):
-                        if multi_item in mario.items:
-                            mario.items.remove(multi_item)
-                            break
+        if items := kwargs.get("item"):
+            if type(items) is not list:
+                items = [items]
+            for item in items:
+                if item in multiuse_progression_items:
+                    have_any_req_item = True in (multi_item in mario.items
+                                                 for multi_item in multiuse_progression_items.get(item))
+                    if have_any_req_item:
+                        # remove single multiuse item #TODO very janky, pls rework
+                        for multi_item in multiuse_progression_items.get(item):
+                            if multi_item in mario.items:
+                                mario.items.remove(multi_item)
+                                break
+                        return True
+                if item in mario.items:
                     return True
-            if item in mario.items:
-                return True
         # StarPieces
         starpieces = kwargs.get("starpieces")
         if starpieces is not None and get_starpiece_count() >= starpieces:


### PR DESCRIPTION
One possible sanity check of the randomization logic if making sure that "absolutely everything vanilla' is a possible result. Currently there are a few reasons why such a result is impossible, this pull request changes that.

Changes that apply always (keysanity ON or off):

* Change Cake from replenishable to non-replenishable, and change Gourmet Guy to expect you to cook a Cake Mix instead of giving him the non-replenishable cake. Reasoning: this is the "logic" that the original game uses.

Changes that only apply when key items are restricted to their original dungeon (keysanity OFF):

* Assume the player has Super Boots when filling items for Tubba Blubba's Castle, Flower Fields, and Crystal Palace. (Currently keys are placed only in places the super boots don't block off.)

* In Toy Box, assume that if the player has the Toy Train, they are able to throw it inside, that if they have the Cake Mix they can cook it, and that if they have the Dictionary+Mystery Note they can translate it. (Currently keys are all frontloaded at blue station.)

* Treat the 4 items in the Toad Town Storeroom as if they were inside Toy Box, meaning that keys such as the Toy Train can be randomized there. (I didn't give any other Toad Town checks are given this treatment though, not even the rewards for returning Dictionary/Calculator/Mailbag/FryingPan, but that's something to consider too.)


Everything here should be taken more as me demonstrating suggestions than anything, and is worth discussing, especially the storeroom change.