### PR TITLE
hammer logic fixes

### DIFF
--- a/maps/graph_edges/edges_iwa.py
+++ b/maps/graph_edges/edges_iwa.py
@@ -15,7 +15,7 @@ edges_iwa = [
     {"from": {"map": "IWA_00", "id": "ItemB"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemB (Coin) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemC"},   "reqs": []}, #* Mt Rugged 1 Exit Left -> ItemC (Coin)
     {"from": {"map": "IWA_00", "id": "ItemC"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemC (Coin) -> Mt Rugged 1 Exit Left
-    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [require(hammer=1,partner=["Kooper","Bombette"]),require(flag="RF_Missable")]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
+    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [require(hammer=1),require(flag="RF_Missable")]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
     {"from": {"map": "IWA_00", "id": "ItemD"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemD (WhackasBump) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "YBlockA"}, "reqs": []}, #* Mt Rugged 1 Exit Left -> YBlockA (SleepySheep)
     {"from": {"map": "IWA_00", "id": "YBlockA"}, "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* YBlockA (SleepySheep) -> Mt Rugged 1 Exit Left

--- a/maps/graph_edges/edges_iwa.py
+++ b/maps/graph_edges/edges_iwa.py
@@ -15,7 +15,7 @@ edges_iwa = [
     {"from": {"map": "IWA_00", "id": "ItemB"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemB (Coin) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemC"},   "reqs": []}, #* Mt Rugged 1 Exit Left -> ItemC (Coin)
     {"from": {"map": "IWA_00", "id": "ItemC"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemC (Coin) -> Mt Rugged 1 Exit Left
-    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [require(hammer=1),require(flag="RF_Missable")]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
+    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [require(hammer=1,partner=["Kooper","Bombette"]),require(flag="RF_Missable")]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
     {"from": {"map": "IWA_00", "id": "ItemD"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemD (WhackasBump) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "YBlockA"}, "reqs": []}, #* Mt Rugged 1 Exit Left -> YBlockA (SleepySheep)
     {"from": {"map": "IWA_00", "id": "YBlockA"}, "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* YBlockA (SleepySheep) -> Mt Rugged 1 Exit Left
@@ -78,11 +78,11 @@ edges_iwa = [
     {"from": {"map": "IWA_03", "id": "ItemI"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemI (Coin) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemJ"},   "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> ItemJ (Coin) (bottom2)
     {"from": {"map": "IWA_03", "id": "ItemJ"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemJ (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockA (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockA (Coin)
     {"from": {"map": "IWA_03", "id": "YBlockA"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockB"}, "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> YBlockB (Mushroom)
     {"from": {"map": "IWA_03", "id": "YBlockB"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockB (Mushroom) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockC"}, "reqs": [require(hammer=1)]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockC (HoneySyrup)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockC (HoneySyrup)
     {"from": {"map": "IWA_03", "id": "YBlockC"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockC (HoneySyrup) -> Mt Rugged 4 Exit Bottom Right
 
     # IWA_04 Suspension Bridge

--- a/maps/graph_edges/edges_jan.py
+++ b/maps/graph_edges/edges_jan.py
@@ -151,7 +151,7 @@ edges_jan = [
     {"from": {"map": "JAN_05", "id": 2},         "to": {"map": "JAN_05", "id": "RBlockA"}, "reqs": [require(partner="Sushie")]}, #* SE Jungle (Quake Hammer) Exit Right-> RBlockA (PowerQuake)
     {"from": {"map": "JAN_05", "id": "RBlockA"}, "to": {"map": "JAN_05", "id": 2},         "reqs": [require(partner="Sushie")]}, #* RBlockA (PowerQuake) -> SE Jungle (Quake Hammer) Exit Right
 
-    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 3}, "reqs": [require(flag="RF_YoshiKidsMissing"),can_shake_trees], "pseudoitems": ["RF_SavedYoshiKid_1"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 3}, "reqs": [require(flag="RF_YoshiKidsMissing"),require(hammer=1)], "pseudoitems": ["RF_SavedYoshiKid_1"]}, #+ Save Yoshi Kid
 
     # JAN_06 NE Jungle (Raven Statue)
     {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_05", "id": 3}, "reqs": []}, # NE Jungle (Raven Statue) Exit Bottom -> SE Jungle (Quake Hammer) Exit Top

--- a/maps/graph_edges/edges_kmr.py
+++ b/maps/graph_edges/edges_kmr.py
@@ -62,7 +62,7 @@ edges_kmr  = [
     {"from": {"map": "KMR_03", "id": 0}, "to": {"map": "KMR_03", "id": 1}, "reqs": []}, #? Bottom of the Cliff Exit Left -> Bottom of the Cliff Exit Right
     {"from": {"map": "KMR_03", "id": 1}, "to": {"map": "KMR_03", "id": 0}, "reqs": []}, #? Bottom of the Cliff Exit Right -> Bottom of the Cliff Exit Left
     
-    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "YBlockA"},       "reqs": [require(hammer=1)]}, #* Bottom of the Cliff Exit Left -> YBlockA (Coin)
+    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "YBlockA"},       "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Bottom of the Cliff Exit Left -> YBlockA (Coin)
     {"from": {"map": "KMR_03", "id": "YBlockA"},       "to": {"map": "KMR_03", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> Bottom of the Cliff Exit Left
     {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "Tree1_Drop1A"},  "reqs": [can_shake_trees]}, #* Bottom of the Cliff Exit Left -> Tree1_Drop1A (Mushroom)
     {"from": {"map": "KMR_03", "id": "Tree1_Drop1A"},  "to": {"map": "KMR_03", "id": 0},               "reqs": []}, #* Tree1_Drop1A (Mushroom) -> Bottom of the Cliff Exit Left
@@ -138,7 +138,7 @@ edges_kmr  = [
     {"from": {"map": "KMR_11", "id": "Tree1_Drop1A"}, "to": {"map": "KMR_11", "id": 0},              "reqs": []}, #* Tree1_Drop1A (StarPiece) -> Goomba King's Castle Exit Left
     {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "HiddenPanel"},  "reqs": [can_flip_panels]}, #* Goomba King's Castle Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "KMR_11", "id": "HiddenPanel"},  "to": {"map": "KMR_11", "id": 1},              "reqs": []}, #* HiddenPanel (StarPiece) -> Goomba King's Castle Exit Right
-    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "YBlockA"},      "reqs": [require(hammer=1)]}, #* Goomba King's Castle Exit Right -> YBlockA (SuperShroom)
+    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "YBlockA"},      "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Goomba King's Castle Exit Right -> YBlockA (SuperShroom)
     {"from": {"map": "KMR_11", "id": "YBlockA"},      "to": {"map": "KMR_11", "id": 1},              "reqs": []}, #* YBlockA (SuperShroom) -> Goomba King's Castle Exit Right
 
     # KMR_10 Toad Town Entrance

--- a/maps/graph_edges/edges_pra.py
+++ b/maps/graph_edges/edges_pra.py
@@ -71,7 +71,7 @@ edges_pra = [
     {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_03", "id": 2}, "reqs": []}, # Red Key Hall Door West -> Save Room Basement Door
     {"from": {"map": "PRA_09", "id": 1}, "to": {"map": "PRA_11", "id": 0}, "reqs": []}, # Red Key Hall Bombable Wall -> Red Key Room Bombable Wall
     
-    {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_09", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Red Key Hall Door West -> Red Key Hall Bombable Wall
+    {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_09", "id": 1}, "reqs": [require(partner="Bombette"),require(hammer=1)]}, #? Red Key Hall Door West -> Red Key Hall Bombable Wall
     {"from": {"map": "PRA_09", "id": 1}, "to": {"map": "PRA_09", "id": 0}, "reqs": []}, #? Red Key Hall Bombable Wall -> Red Key Hall Door West
 
     # PRA_10 P-Down, D-Up Hall
@@ -144,7 +144,7 @@ edges_pra = [
     {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_35", "id": 1}, "reqs": []}, # Reflection Mimic Room Door West -> Triple Dip Room Door East
     {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_20", "id": 0}, "reqs": []}, # Reflection Mimic Room Bombable Wall -> Mirrored Door Room Bombable Wall
     
-    {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_19", "id": 1}, "reqs": [require(partner="Kooper")]}, #? Reflection Mimic Room Door West -> Reflection Mimic Room Bombable Wall
+    {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_19", "id": 1}, "reqs": [require(partner="Kooper"),require(hammer=1)]}, #? Reflection Mimic Room Door West -> Reflection Mimic Room Bombable Wall
     {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_19", "id": 0}, "reqs": []}, #? Reflection Mimic Room Bombable Wall -> Reflection Mimic Room Door West
 
     # PRA_20 Mirrored Door Room

--- a/maps/graph_edges/edges_sbk.py
+++ b/maps/graph_edges/edges_sbk.py
@@ -9,9 +9,9 @@ edges_sbk = [
     {"from": {"map": "SBK_00", "id": 1}, "to": {"map": "SBK_00", "id": 3}, "reqs": []}, #? N3W3 Exit East -> N3W3 Exit South
     {"from": {"map": "SBK_00", "id": 3}, "to": {"map": "SBK_00", "id": 1}, "reqs": []}, #? N3W3 Exit South -> N3W3 Exit East
     
-    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* N3W3 Exit East -> YBlockA (FrightJar)
+    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N3W3 Exit East -> YBlockA (FrightJar)
     {"from": {"map": "SBK_00", "id": "YBlockA"}, "to": {"map": "SBK_00", "id": 1},         "reqs": []}, #* YBlockA (FrightJar) -> N3W3 Exit East
-    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockB"}, "reqs": [require(hammer=1)]}, #* N3W3 Exit East -> YBlockB (Coin)
+    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N3W3 Exit East -> YBlockB (Coin)
     {"from": {"map": "SBK_00", "id": "YBlockB"}, "to": {"map": "SBK_00", "id": 1},         "reqs": []}, #* YBlockB (Coin) -> N3W3 Exit East
 
     # SBK_01 N3W2
@@ -148,9 +148,9 @@ edges_sbk = [
     {"from": {"map": "SBK_14", "id": 0}, "to": {"map": "SBK_14", "id": 4}, "reqs": []}, #? N2E1 (Tweester A) Exit West -> N2E1 (Tweester A) Tweester
     {"from": {"map": "SBK_14", "id": 4}, "to": {"map": "SBK_14", "id": 0}, "reqs": []}, #? N2E1 (Tweester A) Tweester -> N2E1 (Tweester A) Exit West
     
-    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* N2E1 (Tweester A) Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N2E1 (Tweester A) Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_14", "id": "YBlockA"}, "to": {"map": "SBK_14", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> N2E1 (Tweester A) Exit West
-    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockB"}, "reqs": [require(hammer=1)]}, #* N2E1 (Tweester A) Exit West -> YBlockB (HoneySyrup)
+    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N2E1 (Tweester A) Exit West -> YBlockB (HoneySyrup)
     {"from": {"map": "SBK_14", "id": "YBlockB"}, "to": {"map": "SBK_14", "id": 0},         "reqs": []}, #* YBlockB (HoneySyrup) -> N2E1 (Tweester A) Exit West
 
     # SBK_15 N2E2
@@ -186,11 +186,11 @@ edges_sbk = [
     {"from": {"map": "SBK_20", "id": 1}, "to": {"map": "SBK_20", "id": 3}, "reqs": []}, #? N1W3 Special Block Exit East -> N1W3 Special Block Exit South
     {"from": {"map": "SBK_20", "id": 3}, "to": {"map": "SBK_20", "id": 1}, "reqs": []}, #? N1W3 Special Block Exit South -> N1W3 Special Block Exit East
     
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* N1W3 Special Block Exit East -> YBlockA (Mushroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockA (Mushroom)
     {"from": {"map": "SBK_20", "id": "YBlockA"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockA (Mushroom) -> N1W3 Special Block Exit East
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockB"}, "reqs": [require(hammer=1)]}, #* N1W3 Special Block Exit East -> YBlockB (SuperShroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockB (SuperShroom)
     {"from": {"map": "SBK_20", "id": "YBlockB"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockB (SuperShroom) -> N1W3 Special Block Exit East
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockC"}, "reqs": [require(hammer=1)]}, #* N1W3 Special Block Exit East -> YBlockC (UltraShroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockC (UltraShroom)
     {"from": {"map": "SBK_20", "id": "YBlockC"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockC (UltraShroom) -> N1W3 Special Block Exit East
 
     # SBK_21 N1W2
@@ -219,15 +219,15 @@ edges_sbk = [
     {"from": {"map": "SBK_22", "id": 0}, "to": {"map": "SBK_22", "id": 3}, "reqs": []}, #? N1W1 Exit West -> N1W1 Exit South
     {"from": {"map": "SBK_22", "id": 3}, "to": {"map": "SBK_22", "id": 0}, "reqs": []}, #? N1W1 Exit South -> N1W1 Exit West
     
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* N1W1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockA"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockB"}, "reqs": [require(hammer=1)]}, #* N1W1 Exit West -> YBlockB (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockB (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockB"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockB (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockC"}, "reqs": [require(hammer=1)]}, #* N1W1 Exit West -> YBlockC (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockC (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockC"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockC (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockD"}, "reqs": [require(hammer=1)]}, #* N1W1 Exit West -> YBlockD (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockD"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockD (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockD"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockD (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockE"}, "reqs": [require(hammer=1)]}, #* N1W1 Exit West -> YBlockE (FireFlower)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockE"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockE (FireFlower)
     {"from": {"map": "SBK_22", "id": "YBlockE"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockE (FireFlower) -> N1W1 Exit West
 
     # SBK_23 N1 (Tweester B)
@@ -446,7 +446,7 @@ edges_sbk = [
     {"from": {"map": "SBK_43", "id": 0}, "to": {"map": "SBK_43", "id": 3}, "reqs": []}, #? S1 Exit West -> S1 Exit South
     {"from": {"map": "SBK_43", "id": 3}, "to": {"map": "SBK_43", "id": 0}, "reqs": []}, #? S1 Exit South -> S1 Exit West
     
-    {"from": {"map": "SBK_43", "id": 0},         "to": {"map": "SBK_43", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* S1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_43", "id": 0},         "to": {"map": "SBK_43", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_43", "id": "YBlockA"}, "to": {"map": "SBK_43", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> S1 Exit West
 
     # SBK_44 S1E1
@@ -494,7 +494,7 @@ edges_sbk = [
     
     {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* S1E3 North of Oasis Exit West -> HiddenYBlockA (LifeShroom)
     {"from": {"map": "SBK_46", "id": "HiddenYBlockA"}, "to": {"map": "SBK_46", "id": 0},               "reqs": []}, #* HiddenYBlockA (LifeShroom) -> S1E3 North of Oasis Exit West
-    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "YBlockA"},       "reqs": [require(hammer=1)]}, #* S1E3 North of Oasis Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "YBlockA"},       "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S1E3 North of Oasis Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_46", "id": "YBlockA"},       "to": {"map": "SBK_46", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> S1E3 North of Oasis Exit West
 
     # SBK_50 S2W3
@@ -643,7 +643,7 @@ edges_sbk = [
     {"from": {"map": "SBK_64", "id": 0}, "to": {"map": "SBK_64", "id": 2}, "reqs": []}, #? S3E1 Exit West -> S3E1 Exit North
     {"from": {"map": "SBK_64", "id": 2}, "to": {"map": "SBK_64", "id": 0}, "reqs": []}, #? S3E1 Exit North -> S3E1 Exit West
     
-    {"from": {"map": "SBK_64", "id": 0},         "to": {"map": "SBK_64", "id": "YBlockA"}, "reqs": [require(hammer=1)]}, #* S3E1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_64", "id": 0},         "to": {"map": "SBK_64", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S3E1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_64", "id": "YBlockA"}, "to": {"map": "SBK_64", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> S3E1 Exit West
 
     # SBK_65 S3E2


### PR DESCRIPTION
Boots/Partners work on ? blocks on the ground
Partners work on Whacka
Bombette doesn't work on yoshi tree (not that you can get there without hammer anyway)
Crystal Palace duplighosts need hammer

Extra comment: I also noticed a strange issue where fuzzed-out Kooper and Bombette with the "partners always usable" setting aren't able to break the Watt lantern like they usually can. No idea why that would be the case.