### PR TITLE
Prevent double processing edges

### DIFF
--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -136,6 +136,11 @@ def _depth_first_search(
         outgoing_edges = [edge for edge in non_traversable_edges
                                if get_edge_origin_node_id(edge) == node_id]
     logging.debug(f"DFS outgoing_edges {outgoing_edges}")
+
+    # Prevent this node's edges from being double processed by the recursive calls
+    non_traversable_edges[:] = [edge for edge in non_traversable_edges
+                               if get_edge_origin_node_id(edge) != node_id]
+
     for edge in outgoing_edges:
         # Check if all requirements for edge traversal are fulfilled
         if all([r() for r in edge.get("reqs")]):


### PR DESCRIPTION
Occasionally the same edge will get processed more than once by the depth first search. The confirmed bugs caused by this were patched already (https://github.com/icebound777/PMR-SeedGenerator/commit/4d1eefc34bfd2b40fe7c8d2309f04b09f62adf0d, https://github.com/icebound777/PMR-SeedGenerator/commit/159149efe8158974ece6f789712a69e7c7da89e4) but I still think it's possible for keys to be consumed twice for the same lock. (I don't have a seed where this happens to prove it, but I have found that there are always SOME edges that get double-processed in any given seed. For example the STARSPIRIT_5 edge does this on default settings.)

This patch prevents any edge from ever being double processed by making sure that any edge that gets added to `outgoing_edges` gets temporarily removed from non_traversable_edges until we have processed it.