### PR TITLE
Non global mario class

### DIFF
--- a/maps/graph_edges/edges_arn.py
+++ b/maps/graph_edges/edges_arn.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the ARN (Gusty Gulch) area."""
 edges_arn = [
     # ARN_02 Wasteland Ascent 1
@@ -9,7 +7,7 @@ edges_arn = [
     {"from": {"map": "ARN_02", "id": 0}, "to": {"map": "ARN_02", "id": 1}, "reqs": []}, #? Wasteland Ascent 1 Exit West -> Wasteland Ascent 1 Exit East
     {"from": {"map": "ARN_02", "id": 1}, "to": {"map": "ARN_02", "id": 0}, "reqs": []}, #? Wasteland Ascent 1 Exit East -> Wasteland Ascent 1 Exit West
     
-    {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemA"},   "reqs": [require(partner="Kooper")]}, #* Wasteland Ascent 1 Exit West -> ItemA (DizzyDial)
+    {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemA"},   "reqs": [["Kooper"]]}, #* Wasteland Ascent 1 Exit West -> ItemA (DizzyDial)
     {"from": {"map": "ARN_02", "id": "ItemA"},   "to": {"map": "ARN_02", "id": 0},         "reqs": []}, #* ItemA (DizzyDial) -> Wasteland Ascent 1 Exit West
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemB"},   "reqs": []}, #* Wasteland Ascent 1 Exit West -> ItemB (Letter07)
     {"from": {"map": "ARN_02", "id": "ItemB"},   "to": {"map": "ARN_02", "id": 0},         "reqs": []}, #* ItemB (Letter07) -> Wasteland Ascent 1 Exit West
@@ -27,7 +25,7 @@ edges_arn = [
     {"from": {"map": "ARN_03", "id": 0}, "to": {"map": "ARN_03", "id": 1}, "reqs": []}, #? Ghost Town 1 Exit West -> Ghost Town 1 Exit East
     {"from": {"map": "ARN_03", "id": 1}, "to": {"map": "ARN_03", "id": 0}, "reqs": []}, #? Ghost Town 1 Exit East -> Ghost Town 1 Exit West
     
-    {"from": {"map": "ARN_03", "id": 0},         "to": {"map": "ARN_03", "id": "GiftA"},   "reqs": [require(favor="FAVOR_7_01_active")]}, #* Ghost Town 1 Exit West -> GiftA (KootPackage)
+    {"from": {"map": "ARN_03", "id": 0},         "to": {"map": "ARN_03", "id": "GiftA"},   "reqs": [["FAVOR_7_01_active"]]}, #* Ghost Town 1 Exit West -> GiftA (KootPackage)
     {"from": {"map": "ARN_03", "id": "GiftA"},   "to": {"map": "ARN_03", "id": 0},         "reqs": []}, #* GiftA (KootPackage) -> Ghost Town 1 Exit West
     {"from": {"map": "ARN_03", "id": 0},         "to": {"map": "ARN_03", "id": "YBlockA"}, "reqs": []}, #* Ghost Town 1 Exit West -> YBlockA (Coin)
     {"from": {"map": "ARN_03", "id": "YBlockA"}, "to": {"map": "ARN_03", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Ghost Town 1 Exit West
@@ -36,7 +34,7 @@ edges_arn = [
     {"from": {"map": "ARN_04", "id": 0}, "to": {"map": "ARN_02", "id": 1}, "reqs": []}, # Wasteland Ascent 2 Exit West -> Wasteland Ascent 1 Exit East
     {"from": {"map": "ARN_04", "id": 1}, "to": {"map": "DGB_00", "id": 0}, "reqs": []}, # Wasteland Ascent 2 Exit East -> Escape Scene Exit West
     
-    {"from": {"map": "ARN_04", "id": 0}, "to": {"map": "ARN_04", "id": 1}, "reqs": [require(partner="Parakarry")]}, #? Wasteland Ascent 2 Exit West -> Wasteland Ascent 2 Exit East
+    {"from": {"map": "ARN_04", "id": 0}, "to": {"map": "ARN_04", "id": 1}, "reqs": [["Parakarry"]]}, #? Wasteland Ascent 2 Exit West -> Wasteland Ascent 2 Exit East
     {"from": {"map": "ARN_04", "id": 1}, "to": {"map": "ARN_04", "id": 0}, "reqs": []}, #? Wasteland Ascent 2 Exit East -> Wasteland Ascent 2 Exit West
     
     {"from": {"map": "ARN_04", "id": 1},         "to": {"map": "ARN_04", "id": "ItemA"},   "reqs": []}, #* Wasteland Ascent 2 Exit East -> ItemA (StarPiece)
@@ -58,18 +56,18 @@ edges_arn = [
     {"from": {"map": "ARN_07", "id": 1}, "to": {"map": "ARN_03", "id": 0}, "reqs": []}, # Windmill Exterior Exit East -> Ghost Town 1 Exit West
     {"from": {"map": "ARN_07", "id": 2}, "to": {"map": "MIM_12", "id": 1}, "reqs": []}, # Windmill Exterior Exit West -> Exit to Gusty Gulch Exit East
     
-    {"from": {"map": "ARN_07", "id": 1}, "to": {"map": "ARN_07", "id": 0}, "reqs": [require(item="MysticalKey")]}, #? Windmill Exterior Exit East -> Windmill Exterior Enter Windmill
+    {"from": {"map": "ARN_07", "id": 1}, "to": {"map": "ARN_07", "id": 0}, "reqs": [["MysticalKey"]]}, #? Windmill Exterior Exit East -> Windmill Exterior Enter Windmill
     {"from": {"map": "ARN_07", "id": 0}, "to": {"map": "ARN_07", "id": 1}, "reqs": []}, #? Windmill Exterior Enter Windmill -> Windmill Exterior Exit East
     {"from": {"map": "ARN_07", "id": 1}, "to": {"map": "ARN_07", "id": 2}, "reqs": []}, #? Windmill Exterior Exit East -> Windmill Exterior Exit West
     {"from": {"map": "ARN_07", "id": 2}, "to": {"map": "ARN_07", "id": 1}, "reqs": []}, #? Windmill Exterior Exit West -> Windmill Exterior Exit East
     
-    {"from": {"map": "ARN_07", "id": 0}, "to": {"map": "ARN_07", "id": 0}, "reqs": [require(flag="RF_Ch3_HeartFledFirstTunnel")], "pseudoitems": ["STARSPIRIT_3"]}, #+ Windmill Exterior Enter Windmill
+    {"from": {"map": "ARN_07", "id": 0}, "to": {"map": "ARN_07", "id": 0}, "reqs": [["RF_Ch3_HeartFledFirstTunnel"]], "pseudoitems": ["STARSPIRIT_3"]}, #+ Windmill Exterior Enter Windmill
 
     # ARN_08 Windmill Interior
     {"from": {"map": "ARN_08", "id": 0}, "to": {"map": "ARN_07", "id": 0}, "reqs": []}, # Windmill Interior Exit Windmill -> Windmill Exterior Enter Windmill
     {"from": {"map": "ARN_08", "id": 1}, "to": {"map": "ARN_09", "id": 1}, "reqs": []}, # Windmill Interior Into Well -> Windmill Tunnel Entry Spring Exit
     
-    {"from": {"map": "ARN_08", "id": 0}, "to": {"map": "ARN_08", "id": 1}, "reqs": [require(boots=2)]}, #? Windmill Interior Exit Windmill -> Windmill Interior Into Well
+    {"from": {"map": "ARN_08", "id": 0}, "to": {"map": "ARN_08", "id": 1}, "reqs": [["SuperBoots"]]}, #? Windmill Interior Exit Windmill -> Windmill Interior Into Well
     {"from": {"map": "ARN_08", "id": 1}, "to": {"map": "ARN_08", "id": 0}, "reqs": []}, #? Windmill Interior Into Well -> Windmill Interior Exit Windmill
 
     # ARN_09 Windmill Tunnel Entry

--- a/maps/graph_edges/edges_dgb.py
+++ b/maps/graph_edges/edges_dgb.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the DGB (Tubba Blubba's Castle) area."""
 edges_dgb = [
     # DGB_00 Escape Scene
@@ -18,9 +16,9 @@ edges_dgb = [
     {"from": {"map": "DGB_01", "id": 5}, "to": {"map": "DGB_17", "id": 1}, "reqs": []}, # Great Hall Door Door 3F Left -> Save Room (3F) Door Right
     {"from": {"map": "DGB_01", "id": 6}, "to": {"map": "DGB_18", "id": 0}, "reqs": []}, # Great Hall Door Door 3F Right -> Master Bedroom (3F) Door Left
     
-    {"from": {"map": "DGB_01", "id": 0}, "to": {"map": "DGB_01", "id": 1}, "reqs": [require(partner="Bow")]}, #? Great Hall Door 1F Bottom -> Great Hall Door Door 1F Left
+    {"from": {"map": "DGB_01", "id": 0}, "to": {"map": "DGB_01", "id": 1}, "reqs": [["Bow"]]}, #? Great Hall Door 1F Bottom -> Great Hall Door Door 1F Left
     {"from": {"map": "DGB_01", "id": 1}, "to": {"map": "DGB_01", "id": 0}, "reqs": []}, #? Great Hall Door Door 1F Left -> Great Hall Door 1F Bottom
-    {"from": {"map": "DGB_01", "id": 0}, "to": {"map": "DGB_01", "id": 2}, "reqs": [require(item="TubbaCastleKey")]}, #? Great Hall Door 1F Bottom -> Great Hall Door Door 1F Right
+    {"from": {"map": "DGB_01", "id": 0}, "to": {"map": "DGB_01", "id": 2}, "reqs": [[{"TubbaCastleKey": 1}]]}, #? Great Hall Door 1F Bottom -> Great Hall Door Door 1F Right
     #! , require(partner="Bow") ^ 
     {"from": {"map": "DGB_01", "id": 2}, "to": {"map": "DGB_01", "id": 0}, "reqs": []}, #? Great Hall Door Door 1F Right -> Great Hall Door 1F Bottom
     {"from": {"map": "DGB_01", "id": 3}, "to": {"map": "DGB_01", "id": 4}, "reqs": []}, #? Great Hall Door Door 2F Left -> Great Hall Door Door 2F Right
@@ -54,7 +52,7 @@ edges_dgb = [
     {"from": {"map": "DGB_03", "id": 0}, "to": {"map": "DGB_03", "id": 2}, "reqs": []}, #? Table/Clock Room (1/2F) Door 1F Far Left -> Table/Clock Room (1/2F) Door 1F Top Left
     {"from": {"map": "DGB_03", "id": 2}, "to": {"map": "DGB_03", "id": 0}, "reqs": []}, #? Table/Clock Room (1/2F) Door 1F Top Left -> Table/Clock Room (1/2F) Door 1F Far Left
     {"from": {"map": "DGB_03", "id": 3}, "to": {"map": "DGB_03", "id": 4}, "reqs": []}, #? Table/Clock Room (1/2F) Door 2F Far Left -> Table/Clock Room (1/2F) Door 2F Far Right
-    {"from": {"map": "DGB_03", "id": 4}, "to": {"map": "DGB_03", "id": 3}, "reqs": [require(item="TubbaCastleKey")]}, #? Table/Clock Room (1/2F) Door 2F Far Right -> Table/Clock Room (1/2F) Door 2F Far Left
+    {"from": {"map": "DGB_03", "id": 4}, "to": {"map": "DGB_03", "id": 3}, "reqs": [[{"TubbaCastleKey": 2}]]}, #? Table/Clock Room (1/2F) Door 2F Far Right -> Table/Clock Room (1/2F) Door 2F Far Left
     {"from": {"map": "DGB_03", "id": 4}, "to": {"map": "DGB_03", "id": 5}, "reqs": []}, #? Table/Clock Room (1/2F) Door 2F Far Right -> Table/Clock Room (1/2F) 2F Behind The Clock
     {"from": {"map": "DGB_03", "id": 5}, "to": {"map": "DGB_03", "id": 4}, "reqs": []}, #? Table/Clock Room (1/2F) 2F Behind The Clock -> Table/Clock Room (1/2F) Door 2F Far Right
     
@@ -72,7 +70,7 @@ edges_dgb = [
     {"from": {"map": "DGB_05", "id": 0}, "to": {"map": "DGB_03", "id": 2}, "reqs": []}, # Stairs Above Basement Door Top -> Table/Clock Room (1/2F) Door 1F Top Left
     {"from": {"map": "DGB_05", "id": 1}, "to": {"map": "DGB_06", "id": 1}, "reqs": []}, # Stairs Above Basement Hole Bottom -> Basement Fall From Ceiling
     
-    {"from": {"map": "DGB_05", "id": 0}, "to": {"map": "DGB_05", "id": 1}, "reqs": [require(boots=2)]}, #? Stairs Above Basement Door Top -> Stairs Above Basement Hole Bottom
+    {"from": {"map": "DGB_05", "id": 0}, "to": {"map": "DGB_05", "id": 1}, "reqs": [["SuperBoots"]]}, #? Stairs Above Basement Door Top -> Stairs Above Basement Hole Bottom
     {"from": {"map": "DGB_05", "id": 1}, "to": {"map": "DGB_05", "id": 0}, "reqs": []}, #? Stairs Above Basement Hole Bottom -> Stairs Above Basement Door Top
 
     # DGB_06 Basement
@@ -94,7 +92,7 @@ edges_dgb = [
     {"from": {"map": "DGB_08", "id": 0}, "to": {"map": "DGB_01", "id": 2}, "reqs": []}, # East Hall (1/2F) Door 1F Left -> Great Hall Door Door 1F Right
     {"from": {"map": "DGB_08", "id": 1}, "to": {"map": "DGB_01", "id": 4}, "reqs": []}, # East Hall (1/2F) Door 2F Left -> Great Hall Door Door 2F Right
     
-    {"from": {"map": "DGB_08", "id": 0}, "to": {"map": "DGB_08", "id": 1}, "reqs": [require(partner="Bow")]}, #? East Hall (1/2F) Door 1F Left -> East Hall (1/2F) Door 2F Left
+    {"from": {"map": "DGB_08", "id": 0}, "to": {"map": "DGB_08", "id": 1}, "reqs": [["Bow"]]}, #? East Hall (1/2F) Door 1F Left -> East Hall (1/2F) Door 2F Left
     {"from": {"map": "DGB_08", "id": 1}, "to": {"map": "DGB_08", "id": 0}, "reqs": []}, #? East Hall (1/2F) Door 2F Left -> East Hall (1/2F) Door 1F Left
 
     # DGB_09 West Hall (2F)
@@ -107,7 +105,7 @@ edges_dgb = [
     {"from": {"map": "DGB_09", "id": 1}, "to": {"map": "DGB_09", "id": 0}, "reqs": []}, #? West Hall (2F) Door Far Right -> West Hall (2F) Door Far Left
     {"from": {"map": "DGB_09", "id": 0}, "to": {"map": "DGB_09", "id": 2}, "reqs": []}, #? West Hall (2F) Door Far Left -> West Hall (2F) Door Top Left
     {"from": {"map": "DGB_09", "id": 2}, "to": {"map": "DGB_09", "id": 0}, "reqs": []}, #? West Hall (2F) Door Top Left -> West Hall (2F) Door Far Left
-    {"from": {"map": "DGB_09", "id": 0}, "to": {"map": "DGB_09", "id": 3}, "reqs": [require(partner="Bombette")]}, #? West Hall (2F) Door Far Left -> West Hall (2F) Cracked Wall
+    {"from": {"map": "DGB_09", "id": 0}, "to": {"map": "DGB_09", "id": 3}, "reqs": [["Bombette"]]}, #? West Hall (2F) Door Far Left -> West Hall (2F) Cracked Wall
     {"from": {"map": "DGB_09", "id": 3}, "to": {"map": "DGB_09", "id": 0}, "reqs": []}, #? West Hall (2F) Cracked Wall -> West Hall (2F) Door Far Left
 
     # DGB_10 Sealed Room (2F)
@@ -116,11 +114,11 @@ edges_dgb = [
     {"from": {"map": "DGB_10", "id": 2}, "to": {"map": "DGB_11", "id": 2}, "reqs": []}, # Sealed Room (2F) Top Right Hole -> Covered Tables Room (1F) Top Right Ceiling Hole
     {"from": {"map": "DGB_10", "id": 3}, "to": {"map": "DGB_11", "id": 1}, "reqs": []}, # Sealed Room (2F) Bottom Right Hole -> Covered Tables Room (1F) Bottom Right Ceiling Hole
     
-    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 1}, "reqs": [require(boots=2)]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Top Left Hole
+    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 1}, "reqs": [["SuperBoots"]]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Top Left Hole
     {"from": {"map": "DGB_10", "id": 1}, "to": {"map": "DGB_10", "id": 0}, "reqs": []}, #? Sealed Room (2F) Top Left Hole -> Sealed Room (2F) Cracked Wall Bottom Left
-    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 2}, "reqs": [require(boots=2)]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Top Right Hole
+    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 2}, "reqs": [["SuperBoots"]]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Top Right Hole
     {"from": {"map": "DGB_10", "id": 2}, "to": {"map": "DGB_10", "id": 0}, "reqs": []}, #? Sealed Room (2F) Top Right Hole -> Sealed Room (2F) Cracked Wall Bottom Left
-    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 3}, "reqs": [require(boots=2)]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Bottom Right Hole
+    {"from": {"map": "DGB_10", "id": 0}, "to": {"map": "DGB_10", "id": 3}, "reqs": [["SuperBoots"]]}, #? Sealed Room (2F) Cracked Wall Bottom Left -> Sealed Room (2F) Bottom Right Hole
     {"from": {"map": "DGB_10", "id": 3}, "to": {"map": "DGB_10", "id": 0}, "reqs": []}, #? Sealed Room (2F) Bottom Right Hole -> Sealed Room (2F) Cracked Wall Bottom Left
 
     {"from": {"map": "DGB_10", "id": 1}, "to": {"map": "DGB_10", "id": 1}, "reqs": [], "pseudoitems": ["GF_DGB10_BoardedFloor3"]}, #+ Sealed Room (2F) Top Left Hole
@@ -134,34 +132,34 @@ edges_dgb = [
     {"from": {"map": "DGB_11", "id": 0}, "to": {"map": "DGB_11", "id": 1}, "reqs": []}, #? Covered Tables Room (1F) Door Bottom -> Covered Tables Room (1F) Bottom Right Ceiling Hole
     {"from": {"map": "DGB_11", "id": 1}, "to": {"map": "DGB_11", "id": 0}, "reqs": []}, #? Covered Tables Room (1F) Bottom Right Ceiling Hole -> Covered Tables Room (1F) Door Bottom
     {"from": {"map": "DGB_11", "id": 2}, "to": {"map": "DGB_11", "id": 0}, "reqs": []}, #? Covered Tables Room (1F) Top Right Ceiling Hole -> Covered Tables Room (1F) Door Bottom
-    {"from": {"map": "DGB_11", "id": 0}, "to": {"map": "DGB_11", "id": 3}, "reqs": [require(flag="GF_DGB10_BoardedFloor3")]}, #? Covered Tables Room (1F) Door Bottom -> Covered Tables Room (1F) Spring To Ceiling
+    {"from": {"map": "DGB_11", "id": 0}, "to": {"map": "DGB_11", "id": 3}, "reqs": [["GF_DGB10_BoardedFloor3"]]}, #? Covered Tables Room (1F) Door Bottom -> Covered Tables Room (1F) Spring To Ceiling
     {"from": {"map": "DGB_11", "id": 3}, "to": {"map": "DGB_11", "id": 0}, "reqs": []}, #? Covered Tables Room (1F) Spring To Ceiling -> Covered Tables Room (1F) Door Bottom
     
-    {"from": {"map": "DGB_11", "id": 2},       "to": {"map": "DGB_11", "id": "ItemA"}, "reqs": [require(partner="Parakarry")]}, #* Covered Tables Room (1F) Top Right Ceiling Hole -> ItemA (DDownJump)
+    {"from": {"map": "DGB_11", "id": 2},       "to": {"map": "DGB_11", "id": "ItemA"}, "reqs": [["Parakarry"]]}, #* Covered Tables Room (1F) Top Right Ceiling Hole -> ItemA (DDownJump)
     {"from": {"map": "DGB_11", "id": "ItemA"}, "to": {"map": "DGB_11", "id": 2},       "reqs": []}, #* ItemA (DDownJump) -> Covered Tables Room (1F) Top Right Ceiling Hole
 
     # DGB_12 Spike Trap Room (2F)
     {"from": {"map": "DGB_12", "id": 0}, "to": {"map": "DGB_09", "id": 2}, "reqs": []}, # Spike Trap Room (2F) Door Bottom Left -> West Hall (2F) Door Top Left
     
-    {"from": {"map": "DGB_12", "id": 0},        "to": {"map": "DGB_12", "id": "ChestA"}, "reqs": [require(partner="Bow")]}, #* Spike Trap Room (2F) Door Bottom Left -> ChestA (CastleKey1)
+    {"from": {"map": "DGB_12", "id": 0},        "to": {"map": "DGB_12", "id": "ChestA"}, "reqs": [["Bow"]]}, #* Spike Trap Room (2F) Door Bottom Left -> ChestA (CastleKey1)
     {"from": {"map": "DGB_12", "id": "ChestA"}, "to": {"map": "DGB_12", "id": 0},        "reqs": []}, #* ChestA (CastleKey1) -> Spike Trap Room (2F) Door Bottom Left
 
     # DGB_13 Hidden Bedroom (2F)
     {"from": {"map": "DGB_13", "id": 0}, "to": {"map": "DGB_03", "id": 5}, "reqs": []}, # Hidden Bedroom (2F) Door Bottom -> Table/Clock Room (1/2F) 2F Behind The Clock
     
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemA"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemA (MegaRush)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemA"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemA (MegaRush)
     {"from": {"map": "DGB_13", "id": "ItemA"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemA (MegaRush) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemB"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemB (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemB"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemB (Coin)
     {"from": {"map": "DGB_13", "id": "ItemB"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemB (Coin) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemC"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemC (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemC"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemC (Coin)
     {"from": {"map": "DGB_13", "id": "ItemC"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemC (Coin) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemD"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemD (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemD"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemD (Coin)
     {"from": {"map": "DGB_13", "id": "ItemD"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemD (Coin) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemE"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemE (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemE"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemE (Coin)
     {"from": {"map": "DGB_13", "id": "ItemE"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemE (Coin) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemF"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemF (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemF"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemF (Coin)
     {"from": {"map": "DGB_13", "id": "ItemF"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemF (Coin) -> Hidden Bedroom (2F) Door Bottom
-    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemG"}, "reqs": [require(partner="Parakarry")]}, #* Hidden Bedroom (2F) Door Bottom -> ItemG (Coin)
+    {"from": {"map": "DGB_13", "id": 0},       "to": {"map": "DGB_13", "id": "ItemG"}, "reqs": [["Parakarry"]]}, #* Hidden Bedroom (2F) Door Bottom -> ItemG (Coin)
     {"from": {"map": "DGB_13", "id": "ItemG"}, "to": {"map": "DGB_13", "id": 0},       "reqs": []}, #* ItemG (Coin) -> Hidden Bedroom (2F) Door Bottom
 
     # DGB_14 Stairs to Third Floor
@@ -179,7 +177,7 @@ edges_dgb = [
     {"from": {"map": "DGB_15", "id": 1}, "to": {"map": "DGB_17", "id": 0}, "reqs": []}, # West Hall (3F) Door Far Right -> Save Room (3F) Door Left
     {"from": {"map": "DGB_15", "id": 2}, "to": {"map": "DGB_16", "id": 0}, "reqs": []}, # West Hall (3F) Door Top Right -> Sleeping Clubbas Room (3F) Door Bottom Right
     
-    {"from": {"map": "DGB_15", "id": 0}, "to": {"map": "DGB_15", "id": 1}, "reqs": [require(item="TubbaCastleKey")]}, #? West Hall (3F) Door Far Left -> West Hall (3F) Door Far Right
+    {"from": {"map": "DGB_15", "id": 0}, "to": {"map": "DGB_15", "id": 1}, "reqs": [[{"TubbaCastleKey": 3}]]}, #? West Hall (3F) Door Far Left -> West Hall (3F) Door Far Right
     {"from": {"map": "DGB_15", "id": 1}, "to": {"map": "DGB_15", "id": 0}, "reqs": []}, #? West Hall (3F) Door Far Right -> West Hall (3F) Door Far Left
     {"from": {"map": "DGB_15", "id": 0}, "to": {"map": "DGB_15", "id": 2}, "reqs": []}, #? West Hall (3F) Door Far Left -> West Hall (3F) Door Top Right
     {"from": {"map": "DGB_15", "id": 2}, "to": {"map": "DGB_15", "id": 0}, "reqs": []}, #? West Hall (3F) Door Top Right -> West Hall (3F) Door Far Left

--- a/maps/graph_edges/edges_dro.py
+++ b/maps/graph_edges/edges_dro.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the DRO (Dry Dry Outpost) area."""
 edges_dro = [
     # DRO_01 Outpost 1
@@ -9,29 +7,29 @@ edges_dro = [
     
     {"from": {"map": "DRO_01", "id": 0}, "to": {"map": "DRO_01", "id": 1}, "reqs": []}, #? Outpost 1 Exit West -> Outpost 1 Exit East
     {"from": {"map": "DRO_01", "id": 1}, "to": {"map": "DRO_01", "id": 0}, "reqs": []}, #? Outpost 1 Exit East -> Outpost 1 Exit West
-    {"from": {"map": "DRO_01", "id": 0}, "to": {"map": "DRO_01", "id": 2}, "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Outpost 1 Exit West -> Outpost 1 Blue Warp Pipe
+    {"from": {"map": "DRO_01", "id": 0}, "to": {"map": "DRO_01", "id": 2}, "reqs": [["GF_TIK01_WarpPipes"]]}, #? Outpost 1 Exit West -> Outpost 1 Blue Warp Pipe
     {"from": {"map": "DRO_01", "id": 2}, "to": {"map": "DRO_01", "id": 0}, "reqs": []}, #? Outpost 1 Blue Warp Pipe -> Outpost 1 Exit West
     
     {"from": {"map": "DRO_01", "id": 2}, "to": {"map": "DRO_01", "id": 2}, "reqs": [], "pseudoitems": ["GF_TIK01_WarpPipes"]}, #+ Outpost 1 Blue Warp Pipe
     
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "GiftA"},     "reqs": [require(item="Lyrics")]}, #* Outpost 1 Exit West -> GiftA (Melody)
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "GiftA"},     "reqs": [["Lyrics"]]}, #* Outpost 1 Exit West -> GiftA (Melody)
     {"from": {"map": "DRO_01", "id": "GiftA"},     "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* GiftA (Melody) -> Outpost 1 Exit West
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "GiftB"},     "reqs": [require(flag="RF_MouserReturned")]}, #* Outpost 1 Exit West -> GiftB (KootRedJar)
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "GiftB"},     "reqs": [["RF_MouserReturned"]]}, #* Outpost 1 Exit West -> GiftB (KootRedJar)
     {"from": {"map": "DRO_01", "id": "GiftB"},     "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* GiftB (KootRedJar) -> Outpost 1 Exit West
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemA"}, "reqs": [require(flag="RF_MouserReturned")]}, #* Outpost 1 Exit West -> ShopItemA (ThunderBolt)
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemA"}, "reqs": [["RF_MouserReturned"]]}, #* Outpost 1 Exit West -> ShopItemA (ThunderBolt)
     {"from": {"map": "DRO_01", "id": "ShopItemA"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemA (ThunderBolt) -> Outpost 1 Exit West
     # {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemB"}, "reqs": []}, #* Outpost 1 Exit West -> ShopItemB (DustyHammer)
     # {"from": {"map": "DRO_01", "id": "ShopItemB"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemB (DustyHammer) -> Outpost 1 Exit West
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemC"}, "reqs": [require(flag="RF_MouserReturned")]}, #* Outpost 1 Exit West -> ShopItemC (HoneySyrup)
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemC"}, "reqs": [["RF_MouserReturned"]]}, #* Outpost 1 Exit West -> ShopItemC (HoneySyrup)
     {"from": {"map": "DRO_01", "id": "ShopItemC"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemC (HoneySyrup) -> Outpost 1 Exit West
     # {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemD"}, "reqs": []}, #* Outpost 1 Exit West -> ShopItemD (DriedShroom)
     # {"from": {"map": "DRO_01", "id": "ShopItemD"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemD (DriedShroom) -> Outpost 1 Exit West
     # {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemE"}, "reqs": []}, #* Outpost 1 Exit West -> ShopItemE (DriedPasta)
     # {"from": {"map": "DRO_01", "id": "ShopItemE"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemE (DriedPasta) -> Outpost 1 Exit West
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemF"}, "reqs": [require(flag="RF_MouserReturned")]}, #* Outpost 1 Exit West -> ShopItemF (Mushroom)
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": "ShopItemF"}, "reqs": [["RF_MouserReturned"]]}, #* Outpost 1 Exit West -> ShopItemF (Mushroom)
     {"from": {"map": "DRO_01", "id": "ShopItemF"}, "to": {"map": "DRO_01", "id": 0},           "reqs": []}, #* ShopItemF (Mushroom) -> Outpost 1 Exit West
 
-    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": 0}, "reqs": [require(flag="RF_MouserReturned")], "pseudoitems": ["DriedPasta"]}, #+ ShopItemE
+    {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": 0}, "reqs": [["RF_MouserReturned"]], "pseudoitems": ["DriedPasta"]}, #+ ShopItemE
     {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": 0}, "reqs": [], "pseudoitems": ["RF_MouserLeftShop"]}, #+ ShopItemE
     {"from": {"map": "DRO_01", "id": 0},           "to": {"map": "DRO_01", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_DRO_1",
                                                                                                                  "StarPiece_DRO_2",
@@ -45,16 +43,16 @@ edges_dro = [
     # DRO_02 Outpost 2
     {"from": {"map": "DRO_02", "id": 0}, "to": {"map": "DRO_01", "id": 1}, "reqs": []}, # Outpost 2 Exit West -> Outpost 1 Exit East
     
-    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "GiftA"},       "reqs": [require(flag="GF_HOS06_MerluvleeRequestedCrystalBall")]}, #* Outpost 2 Exit West -> GiftA (CrystalBall)
+    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "GiftA"},       "reqs": [["GF_HOS06_MerluvleeRequestedCrystalBall"]]}, #* Outpost 2 Exit West -> GiftA (CrystalBall)
     {"from": {"map": "DRO_02", "id": "GiftA"},       "to": {"map": "DRO_02", "id": 0},             "reqs": []}, #* GiftA (CrystalBall) -> Outpost 2 Exit West
-    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "GiftB"},       "reqs": [require(flag="RF_MouserReturned")]}, #* Outpost 2 Exit West -> GiftB (PulseStone)
+    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "GiftB"},       "reqs": [["RF_MouserReturned"]]}, #* Outpost 2 Exit West -> GiftB (PulseStone)
     {"from": {"map": "DRO_02", "id": "GiftB"},       "to": {"map": "DRO_02", "id": 0},             "reqs": []}, #* GiftB (PulseStone) -> Outpost 2 Exit West
-    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Outpost 2 Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Outpost 2 Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "DRO_02", "id": "HiddenPanel"}, "to": {"map": "DRO_02", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Outpost 2 Exit West
     {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": "ItemA"},       "reqs": []}, #* Outpost 2 Exit West -> ItemA (Letter08)
     {"from": {"map": "DRO_02", "id": "ItemA"},       "to": {"map": "DRO_02", "id": 0},             "reqs": []}, #* ItemA (Letter08) -> Outpost 2 Exit West
  
-    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": 0}, "reqs": [require(flag="RF_MouserLeftShop")], "pseudoitems": ["RF_MouserReturned"]}, #+ Chapter Progress
+    {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": 0}, "reqs": [["RF_MouserLeftShop"]], "pseudoitems": ["RF_MouserReturned"]}, #+ Chapter Progress
     {"from": {"map": "DRO_02", "id": 0},             "to": {"map": "DRO_02", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_DRO_1",
                                                                                                                    "StarPiece_DRO_2",
                                                                                                                    "StarPiece_DRO_3",

--- a/maps/graph_edges/edges_flo.py
+++ b/maps/graph_edges/edges_flo.py
@@ -47,7 +47,7 @@ edges_flo = [
     {"from": {"map": "FLO_17", "id": 0}, "to": {"map": "FLO_17", "id": 1}, "reqs": []}, #? (NE) Fallen Logs Exit Left -> (NE) Fallen Logs Exit Right
     {"from": {"map": "FLO_17", "id": 1}, "to": {"map": "FLO_17", "id": 0}, "reqs": []}, #? (NE) Fallen Logs Exit Right -> (NE) Fallen Logs Exit Left
     
-    {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (NE) Fallen Logs Exit Left -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* (NE) Fallen Logs Exit Left -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "FLO_17", "id": "HiddenYBlockA"}, "to": {"map": "FLO_17", "id": 0},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> (NE) Fallen Logs Exit Left
     {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "ItemA"},         "reqs": []}, #* (NE) Fallen Logs Exit Left -> ItemA (Letter09)
     {"from": {"map": "FLO_17", "id": "ItemA"},         "to": {"map": "FLO_17", "id": 0},               "reqs": []}, #* ItemA (Letter09) -> (NE) Fallen Logs Exit Left
@@ -121,7 +121,7 @@ edges_flo = [
     {"from": {"map": "FLO_24", "id": "YBlockA"},       "to": {"map": "FLO_24", "id": 0},               "reqs": []}, #* YBlockA (DizzyDial) -> (SE) Water Level Room Exit Left
     {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenPanel"},   "reqs": []}, #* (SE) Water Level Room Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "FLO_24", "id": "HiddenPanel"},   "to": {"map": "FLO_24", "id": 1},               "reqs": []}, #* HiddenPanel (StarPiece) -> (SE) Water Level Room Exit Right
-    {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (SE) Water Level Room Exit Right -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* (SE) Water Level Room Exit Right -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "FLO_24", "id": "HiddenYBlockA"}, "to": {"map": "FLO_24", "id": 1},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> (SE) Water Level Room Exit Right
     {"from": {"map": "FLO_24", "id": 0},               "to": {"map": "FLO_24", "id": "Tree1_Drop1A"},  "reqs": [["can_shake_trees"], ["Sushie"], ["RF_Ch6_ReturnedWaterStone"]]}, #* (SE) Water Level Room Exit Left -> Tree1_Drop1A (BubbleBerry)
     {"from": {"map": "FLO_24", "id": "Tree1_Drop1A"},  "to": {"map": "FLO_24", "id": 0},               "reqs": []}, #* Tree1_Drop1A (BubbleBerry) -> (SE) Water Level Room Exit Left
@@ -169,9 +169,9 @@ edges_flo = [
     {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [["GF_FLO23_GaveBlueBerry"]]}, #? (West) Path to Maze Exit Right -> (West) Path to Maze Exit Left
     {"from": {"map": "FLO_23", "id": 1}, "to": {"map": "FLO_23", "id": 0}, "reqs": [["GF_FLO23_GaveBlueBerry"]]}, #? (West) Path to Maze Exit Left -> (West) Path to Maze Exit Right
     
-    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockA (ShootingStar)
+    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockA (ShootingStar)
     {"from": {"map": "FLO_23", "id": "HiddenYBlockA"}, "to": {"map": "FLO_23", "id": 1},               "reqs": []}, #* HiddenYBlockA (ShootingStar) -> (West) Path to Maze Exit Left
-    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockB"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockB (Coin)
+    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockB (Coin)
     {"from": {"map": "FLO_23", "id": "HiddenYBlockB"}, "to": {"map": "FLO_23", "id": 1},               "reqs": []}, #* HiddenYBlockB (Coin) -> (West) Path to Maze Exit Left
 
     {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [["BlueBerry"]], "pseudoitems": ["GF_FLO23_GaveBlueBerry"]}, #+ (West) Path to Maze Exit Right

--- a/maps/graph_edges/edges_flo.py
+++ b/maps/graph_edges/edges_flo.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the FLO (Flower Fields) area."""
 edges_flo = [
     # FLO_00 Center
@@ -24,20 +22,20 @@ edges_flo = [
     {"from": {"map": "FLO_00", "id": 5}, "to": {"map": "FLO_00", "id": 0}, "reqs": []}, #? Center Exit Right -> Center Tree Door
     {"from": {"map": "FLO_00", "id": 0}, "to": {"map": "FLO_00", "id": 6}, "reqs": []}, #? Center Tree Door -> Center Exit Bottom Right
     {"from": {"map": "FLO_00", "id": 6}, "to": {"map": "FLO_00", "id": 0}, "reqs": []}, #? Center Exit Bottom Right -> Center Tree Door
-    {"from": {"map": "FLO_00", "id": 0}, "to": {"map": "FLO_00", "id": 8}, "reqs": [require(flag="RF_Ch6_DestroyedPuffPuffMachine"),
-                                                                                    require(item="MagicalBean"),
-                                                                                    require(item="FertileSoil"),
-                                                                                    require(item="MiracleWater")]}, #? Center Tree Door -> Center Ride Beanstalk Up
+    {"from": {"map": "FLO_00", "id": 0}, "to": {"map": "FLO_00", "id": 8}, "reqs": [["RF_Ch6_DestroyedPuffPuffMachine"],
+                                                                                    ["MagicalBean"],
+                                                                                    ["FertileSoil"],
+                                                                                    ["MiracleWater"]]}, #? Center Tree Door -> Center Ride Beanstalk Up
     {"from": {"map": "FLO_00", "id": 8}, "to": {"map": "FLO_00", "id": 0}, "reqs": []}, #? Center Ride Beanstalk Up -> Center Tree Door
 
     # FLO_16 (NE) Elevators
     {"from": {"map": "FLO_16", "id": 0}, "to": {"map": "FLO_00", "id": 4}, "reqs": []}, # (NE) Elevators Exit Left -> Center Exit Top Right
     {"from": {"map": "FLO_16", "id": 1}, "to": {"map": "FLO_17", "id": 0}, "reqs": []}, # (NE) Elevators Exit Right -> (NE) Fallen Logs Exit Left
     
-    {"from": {"map": "FLO_16", "id": 0}, "to": {"map": "FLO_16", "id": 1}, "reqs": [require(boots=2), require(partner="Lakilester")]}, #? (NE) Elevators Exit Left -> (NE) Elevators Exit Right
-    {"from": {"map": "FLO_16", "id": 1}, "to": {"map": "FLO_16", "id": 0}, "reqs": [require(partner="Lakilester")]}, #? (NE) Elevators Exit Right -> (NE) Elevators Exit Left
+    {"from": {"map": "FLO_16", "id": 0}, "to": {"map": "FLO_16", "id": 1}, "reqs": [["SuperBoots"], ["Lakilester"]]}, #? (NE) Elevators Exit Left -> (NE) Elevators Exit Right
+    {"from": {"map": "FLO_16", "id": 1}, "to": {"map": "FLO_16", "id": 0}, "reqs": [["Lakilester"]]}, #? (NE) Elevators Exit Right -> (NE) Elevators Exit Left
     
-    {"from": {"map": "FLO_16", "id": 1},       "to": {"map": "FLO_16", "id": "ItemA"}, "reqs": [require(boots=2)]}, #* (NE) Elevators Exit Right -> ItemA (StarPiece)
+    {"from": {"map": "FLO_16", "id": 1},       "to": {"map": "FLO_16", "id": "ItemA"}, "reqs": [["SuperBoots"]]}, #* (NE) Elevators Exit Right -> ItemA (StarPiece)
     {"from": {"map": "FLO_16", "id": "ItemA"}, "to": {"map": "FLO_16", "id": 1},       "reqs": []}, #* ItemA (StarPiece) -> (NE) Elevators Exit Right
     {"from": {"map": "FLO_16", "id": 0},       "to": {"map": "FLO_16", "id": "ItemB"}, "reqs": []}, #* (NE) Elevators Exit Left -> ItemB (StinkyHerb)
     {"from": {"map": "FLO_16", "id": "ItemB"}, "to": {"map": "FLO_16", "id": 0},       "reqs": []}, #* ItemB (StinkyHerb) -> (NE) Elevators Exit Left
@@ -49,7 +47,7 @@ edges_flo = [
     {"from": {"map": "FLO_17", "id": 0}, "to": {"map": "FLO_17", "id": 1}, "reqs": []}, #? (NE) Fallen Logs Exit Left -> (NE) Fallen Logs Exit Right
     {"from": {"map": "FLO_17", "id": 1}, "to": {"map": "FLO_17", "id": 0}, "reqs": []}, #? (NE) Fallen Logs Exit Right -> (NE) Fallen Logs Exit Left
     
-    {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* (NE) Fallen Logs Exit Left -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (NE) Fallen Logs Exit Left -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "FLO_17", "id": "HiddenYBlockA"}, "to": {"map": "FLO_17", "id": 0},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> (NE) Fallen Logs Exit Left
     {"from": {"map": "FLO_17", "id": 0},               "to": {"map": "FLO_17", "id": "ItemA"},         "reqs": []}, #* (NE) Fallen Logs Exit Left -> ItemA (Letter09)
     {"from": {"map": "FLO_17", "id": "ItemA"},         "to": {"map": "FLO_17", "id": 0},               "reqs": []}, #* ItemA (Letter09) -> (NE) Fallen Logs Exit Left
@@ -57,7 +55,7 @@ edges_flo = [
     # FLO_18 (NE) Puff Puff Machine
     {"from": {"map": "FLO_18", "id": 0}, "to": {"map": "FLO_17", "id": 1}, "reqs": []}, # (NE) Puff Puff Machine Exit Left -> (NE) Fallen Logs Exit Right
 
-    {"from": {"map": "FLO_18", "id": 0}, "to": {"map": "FLO_18", "id": 0}, "reqs": [require(hammer=1, partner="Bombette")], "pseudoitems": ["RF_Ch6_DestroyedPuffPuffMachine"]}, #+ (NE) Puff Puff Machine Exit Left
+    {"from": {"map": "FLO_18", "id": 0}, "to": {"map": "FLO_18", "id": 0}, "reqs": [["Hammer","Bombette"]], "pseudoitems": ["RF_Ch6_DestroyedPuffPuffMachine"]}, #+ (NE) Puff Puff Machine Exit Left
 
     # FLO_09 (East) Triple Tree Path
     {"from": {"map": "FLO_09", "id": 0}, "to": {"map": "FLO_00", "id": 5}, "reqs": []}, # (East) Triple Tree Path Exit Left -> Center Exit Right
@@ -66,7 +64,7 @@ edges_flo = [
     {"from": {"map": "FLO_09", "id": 0}, "to": {"map": "FLO_09", "id": 1}, "reqs": []}, #? (East) Triple Tree Path Exit Left -> (East) Triple Tree Path Exit Right
     {"from": {"map": "FLO_09", "id": 1}, "to": {"map": "FLO_09", "id": 0}, "reqs": []}, #? (East) Triple Tree Path Exit Right -> (East) Triple Tree Path Exit Left
     
-    {"from": {"map": "FLO_09", "id": 0},             "to": {"map": "FLO_09", "id": "Tree1_Drop1"}, "reqs": [can_shake_trees]}, #* (East) Triple Tree Path Exit Left -> Tree1_Drop1 (HappyFlowerB)
+    {"from": {"map": "FLO_09", "id": 0},             "to": {"map": "FLO_09", "id": "Tree1_Drop1"}, "reqs": [["can_shake_trees"]]}, #* (East) Triple Tree Path Exit Left -> Tree1_Drop1 (HappyFlowerB)
     {"from": {"map": "FLO_09", "id": "Tree1_Drop1"}, "to": {"map": "FLO_09", "id": 0},             "reqs": []}, #* Tree1_Drop1 (HappyFlowerB) -> (East) Triple Tree Path Exit Left
     {"from": {"map": "FLO_09", "id": 0},             "to": {"map": "FLO_09", "id": "ItemA"},       "reqs": []}, #* (East) Triple Tree Path Exit Left -> ItemA (StinkyHerb)
     {"from": {"map": "FLO_09", "id": "ItemA"},       "to": {"map": "FLO_09", "id": 0},             "reqs": []}, #* ItemA (StinkyHerb) -> (East) Triple Tree Path Exit Left
@@ -78,38 +76,38 @@ edges_flo = [
     {"from": {"map": "FLO_03", "id": 0}, "to": {"map": "FLO_03", "id": 1}, "reqs": []}, #? (East) Petunia's Field Exit Left -> (East) Petunia's Field Exit Right
     {"from": {"map": "FLO_03", "id": 1}, "to": {"map": "FLO_03", "id": 0}, "reqs": []}, #? (East) Petunia's Field Exit Right -> (East) Petunia's Field Exit Left
     
-    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "HiddenPanel"},  "reqs": [can_flip_panels]}, #* (East) Petunia's Field Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "HiddenPanel"},  "reqs": [["can_flip_panels"]]}, #* (East) Petunia's Field Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "FLO_03", "id": "HiddenPanel"},  "to": {"map": "FLO_03", "id": 0},              "reqs": []}, #* HiddenPanel (StarPiece) -> (East) Petunia's Field Exit Left
     {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "GiftA"},        "reqs": []}, #* (East) Petunia's Field Exit Left -> GiftA (MagicalBean)
     {"from": {"map": "FLO_03", "id": "GiftA"},        "to": {"map": "FLO_03", "id": 0},              "reqs": []}, #* GiftA (MagicalBean) -> (East) Petunia's Field Exit Left
-    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* (East) Petunia's Field Exit Left -> Tree1_Drop1A (RedBerry)
+    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* (East) Petunia's Field Exit Left -> Tree1_Drop1A (RedBerry)
     {"from": {"map": "FLO_03", "id": "Tree1_Drop1A"}, "to": {"map": "FLO_03", "id": 0},              "reqs": []}, #* Tree1_Drop1A (RedBerry) -> (East) Petunia's Field Exit Left
-    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "Tree1_Drop1B"}, "reqs": [can_shake_trees]}, #* (East) Petunia's Field Exit Left -> Tree1_Drop1B (RedBerry)
+    {"from": {"map": "FLO_03", "id": 0},              "to": {"map": "FLO_03", "id": "Tree1_Drop1B"}, "reqs": [["can_shake_trees"]]}, #* (East) Petunia's Field Exit Left -> Tree1_Drop1B (RedBerry)
     {"from": {"map": "FLO_03", "id": "Tree1_Drop1B"}, "to": {"map": "FLO_03", "id": 0},              "reqs": []}, #* Tree1_Drop1B (RedBerry) -> (East) Petunia's Field Exit Left
 
     # FLO_22 (East) Old Well
     {"from": {"map": "FLO_22", "id": 0}, "to": {"map": "FLO_03", "id": 1}, "reqs": []}, # (East) Old Well Exit Left -> (East) Petunia's Field Exit Right
     
-    {"from": {"map": "FLO_22", "id": 0},       "to": {"map": "FLO_22", "id": "ItemA"}, "reqs": [require(item="BlueBerry")]}, #* (East) Old Well Exit Left -> ItemA (FLowerSaverB)
+    {"from": {"map": "FLO_22", "id": 0},       "to": {"map": "FLO_22", "id": "ItemA"}, "reqs": [["BlueBerry"]]}, #* (East) Old Well Exit Left -> ItemA (FLowerSaverB)
     {"from": {"map": "FLO_22", "id": "ItemA"}, "to": {"map": "FLO_22", "id": 0},       "reqs": []}, #* ItemA (FLowerSaverB) -> (East) Old Well Exit Left
 
     # FLO_08 (SE) Briar Platforming
     {"from": {"map": "FLO_08", "id": 0}, "to": {"map": "FLO_00", "id": 6}, "reqs": []}, # (SE) Briar Platforming Exit Left -> Center Exit Bottom Right
     {"from": {"map": "FLO_08", "id": 1}, "to": {"map": "FLO_24", "id": 0}, "reqs": []}, # (SE) Briar Platforming Exit Right -> (SE) Water Level Room Exit Left
     
-    {"from": {"map": "FLO_08", "id": 0}, "to": {"map": "FLO_08", "id": 1}, "reqs": [require(flag="GF_FLO08_GaveYellowBerry"), require(partner=["Parakarry","Lakilester"])]}, #? (SE) Briar Platforming Exit Left -> (SE) Briar Platforming Exit Right
-    {"from": {"map": "FLO_08", "id": 1}, "to": {"map": "FLO_08", "id": 0}, "reqs": [require(flag="GF_FLO08_GaveYellowBerry"), require(partner=["Parakarry","Lakilester"])]}, #? (SE) Briar Platforming Exit Right -> (SE) Briar Platforming Exit Left
+    {"from": {"map": "FLO_08", "id": 0}, "to": {"map": "FLO_08", "id": 1}, "reqs": [["GF_FLO08_GaveYellowBerry"], ["Parakarry","Lakilester"]]}, #? (SE) Briar Platforming Exit Left -> (SE) Briar Platforming Exit Right
+    {"from": {"map": "FLO_08", "id": 1}, "to": {"map": "FLO_08", "id": 0}, "reqs": [["GF_FLO08_GaveYellowBerry"], ["Parakarry","Lakilester"]]}, #? (SE) Briar Platforming Exit Right -> (SE) Briar Platforming Exit Left
     
     {"from": {"map": "FLO_08", "id": 1},              "to": {"map": "FLO_08", "id": "ItemA"},        "reqs": []}, #* (SE) Briar Platforming Exit Right -> ItemA (StarPiece)
     {"from": {"map": "FLO_08", "id": "ItemA"},        "to": {"map": "FLO_08", "id": 1},              "reqs": []}, #* ItemA (StarPiece) -> (SE) Briar Platforming Exit Right
     {"from": {"map": "FLO_08", "id": 0},              "to": {"map": "FLO_08", "id": "ItemB"},        "reqs": []}, #* (SE) Briar Platforming Exit Left -> ItemB (StinkyHerb)
     {"from": {"map": "FLO_08", "id": "ItemB"},        "to": {"map": "FLO_08", "id": 0},              "reqs": []}, #* ItemB (StinkyHerb) -> (SE) Briar Platforming Exit Left
-    {"from": {"map": "FLO_08", "id": 1},              "to": {"map": "FLO_08", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* (SE) Briar Platforming Exit Right -> Tree1_Drop1A (BlueBerry)
+    {"from": {"map": "FLO_08", "id": 1},              "to": {"map": "FLO_08", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* (SE) Briar Platforming Exit Right -> Tree1_Drop1A (BlueBerry)
     {"from": {"map": "FLO_08", "id": "Tree1_Drop1A"}, "to": {"map": "FLO_08", "id": 1},              "reqs": []}, #* Tree1_Drop1A (BlueBerry) -> (SE) Briar Platforming Exit Right
-    {"from": {"map": "FLO_08", "id": 1},              "to": {"map": "FLO_08", "id": "Tree1_Drop1B"}, "reqs": [can_shake_trees]}, #* (SE) Briar Platforming Exit Right -> ItemA (BlueBerry)
+    {"from": {"map": "FLO_08", "id": 1},              "to": {"map": "FLO_08", "id": "Tree1_Drop1B"}, "reqs": [["can_shake_trees"]]}, #* (SE) Briar Platforming Exit Right -> ItemA (BlueBerry)
     {"from": {"map": "FLO_08", "id": "Tree1_Drop1B"}, "to": {"map": "FLO_08", "id": 1},              "reqs": []}, #* ItemA (BlueBerry) -> (SE) Briar Platforming Exit Right
 
-    {"from": {"map": "FLO_08", "id": 0}, "to": {"map": "FLO_08", "id": 0}, "reqs": [require(item="YellowBerry")], "pseudoitems": ["GF_FLO08_GaveYellowBerry"]}, #+ (SE) Briar Platforming Exit Left
+    {"from": {"map": "FLO_08", "id": 0}, "to": {"map": "FLO_08", "id": 0}, "reqs": [["YellowBerry"]], "pseudoitems": ["GF_FLO08_GaveYellowBerry"]}, #+ (SE) Briar Platforming Exit Left
 
 
     # FLO_24 (SE) Water Level Room
@@ -123,38 +121,38 @@ edges_flo = [
     {"from": {"map": "FLO_24", "id": "YBlockA"},       "to": {"map": "FLO_24", "id": 0},               "reqs": []}, #* YBlockA (DizzyDial) -> (SE) Water Level Room Exit Left
     {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenPanel"},   "reqs": []}, #* (SE) Water Level Room Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "FLO_24", "id": "HiddenPanel"},   "to": {"map": "FLO_24", "id": 1},               "reqs": []}, #* HiddenPanel (StarPiece) -> (SE) Water Level Room Exit Right
-    {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* (SE) Water Level Room Exit Right -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "FLO_24", "id": 1},               "to": {"map": "FLO_24", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (SE) Water Level Room Exit Right -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "FLO_24", "id": "HiddenYBlockA"}, "to": {"map": "FLO_24", "id": 1},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> (SE) Water Level Room Exit Right
-    {"from": {"map": "FLO_24", "id": 0},               "to": {"map": "FLO_24", "id": "Tree1_Drop1A"},  "reqs": [can_shake_trees, require(partner="Sushie"), require(flag="RF_Ch6_ReturnedWaterStone")]}, #* (SE) Water Level Room Exit Left -> Tree1_Drop1A (BubbleBerry)
+    {"from": {"map": "FLO_24", "id": 0},               "to": {"map": "FLO_24", "id": "Tree1_Drop1A"},  "reqs": [["can_shake_trees"], ["Sushie"], ["RF_Ch6_ReturnedWaterStone"]]}, #* (SE) Water Level Room Exit Left -> Tree1_Drop1A (BubbleBerry)
     {"from": {"map": "FLO_24", "id": "Tree1_Drop1A"},  "to": {"map": "FLO_24", "id": 0},               "reqs": []}, #* Tree1_Drop1A (BubbleBerry) -> (SE) Water Level Room Exit Left
-    {"from": {"map": "FLO_24", "id": 0},               "to": {"map": "FLO_24", "id": "Tree1_Drop1B"},  "reqs": [can_shake_trees, require(partner="Sushie"), require(flag="RF_Ch6_ReturnedWaterStone")]}, #* (SE) Water Level Room Exit Left -> Tree1_Drop1B (BubbleBerry)
+    {"from": {"map": "FLO_24", "id": 0},               "to": {"map": "FLO_24", "id": "Tree1_Drop1B"},  "reqs": [["can_shake_trees"], ["Sushie"], ["RF_Ch6_ReturnedWaterStone"]]}, #* (SE) Water Level Room Exit Left -> Tree1_Drop1B (BubbleBerry)
     {"from": {"map": "FLO_24", "id": "Tree1_Drop1B"},  "to": {"map": "FLO_24", "id": 0},               "reqs": []}, #* Tree1_Drop1B (BubbleBerry) -> (SE) Water Level Room Exit Left
 
     # FLO_10 (SE) Lily's Fountain
     {"from": {"map": "FLO_10", "id": 0}, "to": {"map": "FLO_24", "id": 1}, "reqs": []}, # (SE) Lily's Fountain Exit Left -> (SE) Water Level Room Exit Right
     
-    {"from": {"map": "FLO_10", "id": 0},              "to": {"map": "FLO_10", "id": "GiftA"},        "reqs": [require(item="WaterStone")], "pseudoitems": ["RF_Ch6_ReturnedWaterStone"]}, #* (SE) Lily's Fountain Exit Left -> GiftA (MiracleWater)
+    {"from": {"map": "FLO_10", "id": 0},              "to": {"map": "FLO_10", "id": "GiftA"},        "reqs": [["WaterStone"]], "pseudoitems": ["RF_Ch6_ReturnedWaterStone"]}, #* (SE) Lily's Fountain Exit Left -> GiftA (MiracleWater)
     {"from": {"map": "FLO_10", "id": "GiftA"},        "to": {"map": "FLO_10", "id": 0},              "reqs": []}, #* GiftA (MiracleWater) -> (SE) Lily's Fountain Exit Left
-    {"from": {"map": "FLO_10", "id": 0},              "to": {"map": "FLO_10", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* (SE) Lily's Fountain Exit Left -> Tree1_Drop1A (JamminJelly)
+    {"from": {"map": "FLO_10", "id": 0},              "to": {"map": "FLO_10", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* (SE) Lily's Fountain Exit Left -> Tree1_Drop1A (JamminJelly)
     {"from": {"map": "FLO_10", "id": "Tree1_Drop1A"}, "to": {"map": "FLO_10", "id": 0},              "reqs": []}, #* Tree1_Drop1A (JamminJelly) -> (SE) Lily's Fountain Exit Left
 
     # FLO_25 (SW) Path to Crystal Tree
     {"from": {"map": "FLO_25", "id": 0}, "to": {"map": "FLO_00", "id": 3}, "reqs": []}, # (SW) Path to Crystal Tree Exit Right -> Center Exit Bottom Left
     {"from": {"map": "FLO_25", "id": 1}, "to": {"map": "FLO_07", "id": 0}, "reqs": []}, # (SW) Path to Crystal Tree Exit Left -> (SW) Posie and Crystal Tree Exit Right
     
-    {"from": {"map": "FLO_25", "id": 0}, "to": {"map": "FLO_25", "id": 1}, "reqs": [require(flag="GF_FLO25_GaveRedBerry")]}, #? (SW) Path to Crystal Tree Exit Right -> (SW) Path to Crystal Tree Exit Left
-    {"from": {"map": "FLO_25", "id": 1}, "to": {"map": "FLO_25", "id": 0}, "reqs": [require(flag="GF_FLO25_GaveRedBerry")]}, #? (SW) Path to Crystal Tree Exit Left -> (SW) Path to Crystal Tree Exit Right
+    {"from": {"map": "FLO_25", "id": 0}, "to": {"map": "FLO_25", "id": 1}, "reqs": [["GF_FLO25_GaveRedBerry"]]}, #? (SW) Path to Crystal Tree Exit Right -> (SW) Path to Crystal Tree Exit Left
+    {"from": {"map": "FLO_25", "id": 1}, "to": {"map": "FLO_25", "id": 0}, "reqs": [["GF_FLO25_GaveRedBerry"]]}, #? (SW) Path to Crystal Tree Exit Left -> (SW) Path to Crystal Tree Exit Right
     
-    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "HiddenPanel"},  "reqs": [can_flip_panels]}, #* (SW) Path to Crystal Tree Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "HiddenPanel"},  "reqs": [["can_flip_panels"]]}, #* (SW) Path to Crystal Tree Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "FLO_25", "id": "HiddenPanel"},  "to": {"map": "FLO_25", "id": 1},              "reqs": []}, #* HiddenPanel (StarPiece) -> (SW) Path to Crystal Tree Exit Left
     {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "ItemA"},        "reqs": []}, #* (SW) Path to Crystal Tree Exit Left -> ItemA (StinkyHerb)
     {"from": {"map": "FLO_25", "id": "ItemA"},        "to": {"map": "FLO_25", "id": 1},              "reqs": []}, #* ItemA (StinkyHerb) -> (SW) Path to Crystal Tree Exit Left
-    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* (SW) Path to Crystal Tree Exit Left -> Tree1_Drop1A (YellowBerry)
+    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* (SW) Path to Crystal Tree Exit Left -> Tree1_Drop1A (YellowBerry)
     {"from": {"map": "FLO_25", "id": "Tree1_Drop1A"}, "to": {"map": "FLO_25", "id": 1},              "reqs": []}, #* Tree1_Drop1A (YellowBerry) -> (SW) Path to Crystal Tree Exit Left
-    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "Tree1_Drop1B"}, "reqs": [can_shake_trees]}, #* (SW) Path to Crystal Tree Exit Left -> Tree1_Drop1B (YellowBerry)
+    {"from": {"map": "FLO_25", "id": 1},              "to": {"map": "FLO_25", "id": "Tree1_Drop1B"}, "reqs": [["can_shake_trees"]]}, #* (SW) Path to Crystal Tree Exit Left -> Tree1_Drop1B (YellowBerry)
     {"from": {"map": "FLO_25", "id": "Tree1_Drop1B"}, "to": {"map": "FLO_25", "id": 1},              "reqs": []}, #* Tree1_Drop1B (YellowBerry) -> (SW) Path to Crystal Tree Exit Left
 
-    {"from": {"map": "FLO_25", "id": 0}, "to": {"map": "FLO_25", "id": 0}, "reqs": [require(item="RedBerry")], "pseudoitems": ["GF_FLO25_GaveRedBerry"]}, #+ (SW) Path to Crystal Tree Exit Right
+    {"from": {"map": "FLO_25", "id": 0}, "to": {"map": "FLO_25", "id": 0}, "reqs": [["RedBerry"]], "pseudoitems": ["GF_FLO25_GaveRedBerry"]}, #+ (SW) Path to Crystal Tree Exit Right
 
     # FLO_07 (SW) Posie and Crystal Tree
     {"from": {"map": "FLO_07", "id": 0}, "to": {"map": "FLO_25", "id": 1}, "reqs": []}, # (SW) Posie and Crystal Tree Exit Right -> (SW) Path to Crystal Tree Exit Left
@@ -168,15 +166,15 @@ edges_flo = [
     {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_00", "id": 2}, "reqs": []}, # (West) Path to Maze Exit Right -> Center Exit Left
     {"from": {"map": "FLO_23", "id": 1}, "to": {"map": "FLO_11", "id": 0}, "reqs": []}, # (West) Path to Maze Exit Left -> (West) Maze Exit Right
     
-    {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [require(flag="GF_FLO23_GaveBlueBerry")]}, #? (West) Path to Maze Exit Right -> (West) Path to Maze Exit Left
-    {"from": {"map": "FLO_23", "id": 1}, "to": {"map": "FLO_23", "id": 0}, "reqs": [require(flag="GF_FLO23_GaveBlueBerry")]}, #? (West) Path to Maze Exit Left -> (West) Path to Maze Exit Right
+    {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [["GF_FLO23_GaveBlueBerry"]]}, #? (West) Path to Maze Exit Right -> (West) Path to Maze Exit Left
+    {"from": {"map": "FLO_23", "id": 1}, "to": {"map": "FLO_23", "id": 0}, "reqs": [["GF_FLO23_GaveBlueBerry"]]}, #? (West) Path to Maze Exit Left -> (West) Path to Maze Exit Right
     
-    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* (West) Path to Maze Exit Left -> HiddenYBlockA (ShootingStar)
+    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockA (ShootingStar)
     {"from": {"map": "FLO_23", "id": "HiddenYBlockA"}, "to": {"map": "FLO_23", "id": 1},               "reqs": []}, #* HiddenYBlockA (ShootingStar) -> (West) Path to Maze Exit Left
-    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* (West) Path to Maze Exit Left -> HiddenYBlockB (Coin)
+    {"from": {"map": "FLO_23", "id": 1},               "to": {"map": "FLO_23", "id": "HiddenYBlockB"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* (West) Path to Maze Exit Left -> HiddenYBlockB (Coin)
     {"from": {"map": "FLO_23", "id": "HiddenYBlockB"}, "to": {"map": "FLO_23", "id": 1},               "reqs": []}, #* HiddenYBlockB (Coin) -> (West) Path to Maze Exit Left
 
-    {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [require(item="BlueBerry")], "pseudoitems": ["GF_FLO23_GaveBlueBerry"]}, #+ (West) Path to Maze Exit Right
+    {"from": {"map": "FLO_23", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": [["BlueBerry"]], "pseudoitems": ["GF_FLO23_GaveBlueBerry"]}, #+ (West) Path to Maze Exit Right
 
     # FLO_11 (West) Maze
     {"from": {"map": "FLO_11", "id": 0}, "to": {"map": "FLO_23", "id": 1}, "reqs": []}, # (West) Maze Exit Right -> (West) Path to Maze Exit Left
@@ -188,14 +186,14 @@ edges_flo = [
     # FLO_12 (West) Rosie's Trellis
     {"from": {"map": "FLO_12", "id": 0}, "to": {"map": "FLO_11", "id": 1}, "reqs": []}, # (West) Rosie's Trellis Exit Right -> (West) Maze Exit Left
     
-    {"from": {"map": "FLO_12", "id": 0},       "to": {"map": "FLO_12", "id": "GiftA"}, "reqs": [require(item="CrystalBerry")]}, #* (West) Rosie's Trellis Exit Right -> GiftA (WaterStone)
+    {"from": {"map": "FLO_12", "id": 0},       "to": {"map": "FLO_12", "id": "GiftA"}, "reqs": [["CrystalBerry"]]}, #* (West) Rosie's Trellis Exit Right -> GiftA (WaterStone)
     {"from": {"map": "FLO_12", "id": "GiftA"}, "to": {"map": "FLO_12", "id": 0},       "reqs": []}, #* GiftA (WaterStone) -> (West) Rosie's Trellis Exit Right
 
     # FLO_14 (NW) Bubble Flower
     {"from": {"map": "FLO_14", "id": 0}, "to": {"map": "FLO_00", "id": 1}, "reqs": []}, # (NW) Bubble Flower Exit Right -> Center Exit Top Left
     {"from": {"map": "FLO_14", "id": 1}, "to": {"map": "FLO_13", "id": 0}, "reqs": []}, # (NW) Bubble Flower Exit Left -> (NW) Lakilester Exit Right
     
-    {"from": {"map": "FLO_14", "id": 0}, "to": {"map": "FLO_14", "id": 1}, "reqs": [require(partner="Lakilester",item="BubbleBerry")]}, #? (NW) Bubble Flower Exit Right -> (NW) Bubble Flower Exit Left
+    {"from": {"map": "FLO_14", "id": 0}, "to": {"map": "FLO_14", "id": 1}, "reqs": [["Lakilester","BubbleBerry"]]}, #? (NW) Bubble Flower Exit Right -> (NW) Bubble Flower Exit Left
     {"from": {"map": "FLO_14", "id": 1}, "to": {"map": "FLO_14", "id": 0}, "reqs": []}, #? (NW) Bubble Flower Exit Left -> (NW) Bubble Flower Exit Right
     
     {"from": {"map": "FLO_14", "id": 1},       "to": {"map": "FLO_14", "id": "ItemA"}, "reqs": []}, #* (NW) Bubble Flower Exit Left -> ItemA (StarPiece)
@@ -210,17 +208,17 @@ edges_flo = [
     {"from": {"map": "FLO_13", "id": 0}, "to": {"map": "FLO_13", "id": 1}, "reqs": []}, #? (NW) Lakilester Exit Right -> (NW) Lakilester Exit Left
     {"from": {"map": "FLO_13", "id": 1}, "to": {"map": "FLO_13", "id": 0}, "reqs": []}, #? (NW) Lakilester Exit Left -> (NW) Lakilester Exit Right
     
-    {"from": {"map": "FLO_13", "id": 0},         "to": {"map": "FLO_13", "id": "ItemA"},   "reqs": [require(partner="Bombette")]}, #* (NW) Lakilester Exit Right -> ItemA (MegaSmash)
+    {"from": {"map": "FLO_13", "id": 0},         "to": {"map": "FLO_13", "id": "ItemA"},   "reqs": [["Bombette"]]}, #* (NW) Lakilester Exit Right -> ItemA (MegaSmash)
     {"from": {"map": "FLO_13", "id": "ItemA"},   "to": {"map": "FLO_13", "id": 0},         "reqs": []}, #* ItemA (MegaSmash) -> (NW) Lakilester Exit Right
     {"from": {"map": "FLO_13", "id": 0},         "to": {"map": "FLO_13", "id": "ItemB"},   "reqs": []}, #* (NW) Lakilester Exit Right -> ItemB (ShootingStar)
     {"from": {"map": "FLO_13", "id": "ItemB"},   "to": {"map": "FLO_13", "id": 0},         "reqs": []}, #* ItemB (ShootingStar) -> (NW) Lakilester Exit Right
-    {"from": {"map": "FLO_13", "id": 0},         "to": {"map": "FLO_13", "id": "Partner"}, "reqs": [require(flag="RF_Ch6_SpokeWithTheSun")]}, #* (NW) Lakilester Exit Right -> Partner (Lakilester)
+    {"from": {"map": "FLO_13", "id": 0},         "to": {"map": "FLO_13", "id": "Partner"}, "reqs": [["RF_Ch6_SpokeWithTheSun"]]}, #* (NW) Lakilester Exit Right -> Partner (Lakilester)
     {"from": {"map": "FLO_13", "id": "Partner"}, "to": {"map": "FLO_13", "id": 0},         "reqs": []}, #* Partner (Lakilester) -> (NW) Lakilester Exit Right
 
     # FLO_15 (NW) Sun Tower
     {"from": {"map": "FLO_15", "id": 0}, "to": {"map": "FLO_13", "id": 1}, "reqs": []}, # (NW) Sun Tower Exit Right -> (NW) Lakilester Exit Left
 
-    {"from": {"map": "FLO_15", "id": 0}, "to": {"map": "FLO_15", "id": 0}, "reqs": [require(partner="Bombette")], "pseudoitems": ["RF_Ch6_SpokeWithTheSun"]}, #+ (NW) Sun Tower Exit Right
+    {"from": {"map": "FLO_15", "id": 0}, "to": {"map": "FLO_15", "id": 0}, "reqs": [["Bombette"]], "pseudoitems": ["RF_Ch6_SpokeWithTheSun"]}, #+ (NW) Sun Tower Exit Right
 
     # FLO_19 Cloudy Climb
     {"from": {"map": "FLO_19", "id": 1}, "to": {"map": "FLO_21", "id": 0}, "reqs": []}, # Cloudy Climb Exit Right -> Huff N Puff Room Exit Left

--- a/maps/graph_edges/edges_hos.py
+++ b/maps/graph_edges/edges_hos.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the HOS (Shooting Star Summit) area."""
 edges_hos = [
     # HOS_00 Shooting Star Path
@@ -12,17 +10,17 @@ edges_hos = [
     {"from": {"map": "HOS_00", "id": 0}, "to": {"map": "HOS_00", "id": 2}, "reqs": []}, #? Shooting Star Path Exit Left -> Shooting Star Path Exit Bottom Right
     {"from": {"map": "HOS_00", "id": 2}, "to": {"map": "HOS_00", "id": 0}, "reqs": []}, #? Shooting Star Path Exit Bottom Right -> Shooting Star Path Exit Left
     
-    {"from": {"map": "HOS_00", "id": 0},             "to": {"map": "HOS_00", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Shooting Star Path Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "HOS_00", "id": 0},             "to": {"map": "HOS_00", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Shooting Star Path Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "HOS_00", "id": "HiddenPanel"}, "to": {"map": "HOS_00", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Shooting Star Path Exit Left
 
     # HOS_01 Shooting Star Summit
     {"from": {"map": "HOS_01", "id": 0}, "to": {"map": "HOS_00", "id": 1}, "reqs": []}, # Shooting Star Summit Exit Bottom Left -> Shooting Star Path Exit Top Right
     {"from": {"map": "HOS_01", "id": 1}, "to": {"map": "HOS_02", "id": 0}, "reqs": []}, # Shooting Star Summit Ride Up To Starway -> Star Way Ride Down To Summit
     
-    {"from": {"map": "HOS_01", "id": 0}, "to": {"map": "HOS_01", "id": 1}, "reqs": [require(starspirits=7)]}, #? Shooting Star Summit Exit Bottom Left -> Shooting Star Summit Ride Up To Starway
+    {"from": {"map": "HOS_01", "id": 0}, "to": {"map": "HOS_01", "id": 1}, "reqs": [[{"starspirits": 7}]]}, #? Shooting Star Summit Exit Bottom Left -> Shooting Star Summit Ride Up To Starway
     {"from": {"map": "HOS_01", "id": 1}, "to": {"map": "HOS_01", "id": 0}, "reqs": []}, #? Shooting Star Summit Ride Up To Starway -> Shooting Star Summit Exit Bottom Left
     
-    {"from": {"map": "HOS_01", "id": 0},             "to": {"map": "HOS_01", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Shooting Star Summit Exit Bottom Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "HOS_01", "id": 0},             "to": {"map": "HOS_01", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Shooting Star Summit Exit Bottom Left -> HiddenPanel (StarPiece)
     {"from": {"map": "HOS_01", "id": "HiddenPanel"}, "to": {"map": "HOS_01", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Shooting Star Summit Exit Bottom Left
     {"from": {"map": "HOS_01", "id": 0},             "to": {"map": "HOS_01", "id": "ItemA"},       "reqs": []}, #* Shooting Star Summit Exit Bottom Left -> ItemA (StarPiece)
     {"from": {"map": "HOS_01", "id": "ItemA"},       "to": {"map": "HOS_01", "id": 0},             "reqs": []}, #* ItemA (StarPiece) -> Shooting Star Summit Exit Bottom Left
@@ -80,43 +78,43 @@ edges_hos = [
     # HOS_06 Merluvlee's House
     {"from": {"map": "HOS_06", "id": 0}, "to": {"map": "HOS_00", "id": 2}, "reqs": []}, # Merluvlee's House Exit Left -> Shooting Star Path Exit Bottom Right
     
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Merluvlee's House Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Merluvlee's House Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "HOS_06", "id": "HiddenPanel"}, "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "GiftA"},       "reqs": [require(favor="FAVOR_3_03_active"), require(item="CrystalBall")]}, #* Merluvlee's House Exit Left -> GiftA (KootMerluvleeAutograph)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "GiftA"},       "reqs": [["FAVOR_3_03_active"], ["CrystalBall"]]}, #* Merluvlee's House Exit Left -> GiftA (KootMerluvleeAutograph)
     {"from": {"map": "HOS_06", "id": "GiftA"},       "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* GiftA (KootMerluvleeAutograph) -> Merluvlee's House Exit Left
     
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeA"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeA (AttackFXA)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeA"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeA (AttackFXA)
     {"from": {"map": "HOS_06", "id": "ShopBadgeA"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeA (AttackFXA) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeB"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeB (PayOff)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeB"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeB (PayOff)
     {"from": {"map": "HOS_06", "id": "ShopBadgeB"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeB (PayOff) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeC"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeC (ChillOut)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeC"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeC (ChillOut)
     {"from": {"map": "HOS_06", "id": "ShopBadgeC"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeC (ChillOut) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeD"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeD (PrettyLucky)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeD"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeD (PrettyLucky)
     {"from": {"map": "HOS_06", "id": "ShopBadgeD"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeD (PrettyLucky) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeE"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeE (FeelingFine)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeE"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeE (FeelingFine)
     {"from": {"map": "HOS_06", "id": "ShopBadgeE"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeE (FeelingFine) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeF"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeF (HappyHeartA)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeF"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeF (HappyHeartA)
     {"from": {"map": "HOS_06", "id": "ShopBadgeF"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeF (HappyHeartA) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeG"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeG (HappyFlowerA)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeG"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeG (HappyFlowerA)
     {"from": {"map": "HOS_06", "id": "ShopBadgeG"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeG (HappyFlowerA) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeH"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeH (Peekaboo)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeH"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeH (Peekaboo)
     {"from": {"map": "HOS_06", "id": "ShopBadgeH"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeH (Peekaboo) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeI"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeI (ZapTap)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeI"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeI (ZapTap)
     {"from": {"map": "HOS_06", "id": "ShopBadgeI"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeI (ZapTap) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeJ"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeJ (HeartFinder)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeJ"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeJ (HeartFinder)
     {"from": {"map": "HOS_06", "id": "ShopBadgeJ"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeJ (HeartFinder) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeK"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeK (FlowerFinder)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeK"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeK (FlowerFinder)
     {"from": {"map": "HOS_06", "id": "ShopBadgeK"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeK (FlowerFinder) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeL"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeL (HPDrain)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeL"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeL (HPDrain)
     {"from": {"map": "HOS_06", "id": "ShopBadgeL"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeL (HPDrain) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeM"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeM (MoneyMoney)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeM"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeM (MoneyMoney)
     {"from": {"map": "HOS_06", "id": "ShopBadgeM"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeM (MoneyMoney) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeN"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeN (FlowerSaverA)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeN"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeN (FlowerSaverA)
     {"from": {"map": "HOS_06", "id": "ShopBadgeN"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeN (FlowerSaverA) -> Merluvlee's House Exit Left
-    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeO"},  "reqs": [require(starpieces=60)]}, #* Merluvlee's House Exit Left -> ShopBadgeO (PowerPlusA)
+    {"from": {"map": "HOS_06", "id": 0},             "to": {"map": "HOS_06", "id": "ShopBadgeO"},  "reqs": [[{"starpieces": 60}]]}, #* Merluvlee's House Exit Left -> ShopBadgeO (PowerPlusA)
     {"from": {"map": "HOS_06", "id": "ShopBadgeO"},  "to": {"map": "HOS_06", "id": 0},             "reqs": []}, #* ShopBadgeO (PowerPlusA) -> Merluvlee's House Exit Left
 
-    {"from": {"map": "HOS_06", "id": 0}, "to": {"map": "HOS_06", "id": 0}, "reqs": [require(favor="FAVOR_3_03_active")], "pseudoitems": ["GF_HOS06_MerluvleeRequestedCrystalBall"]}, #+ Merluvlee's House Exit Left
+    {"from": {"map": "HOS_06", "id": 0}, "to": {"map": "HOS_06", "id": 0}, "reqs": [["FAVOR_3_03_active"]], "pseudoitems": ["GF_HOS06_MerluvleeRequestedCrystalBall"]}, #+ Merluvlee's House Exit Left
 
     # HOS_20 Riding Star Ship Scene
     {"from": {"map": "HOS_20", "id": 0}, "to": {"map": "HOS_05", "id": 1}, "reqs": []}, # Riding Star Ship Scene Fly To Star Haven -> Star Sanctuary Fly Starship

--- a/maps/graph_edges/edges_isk.py
+++ b/maps/graph_edges/edges_isk.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the ISK (Dry Dry Ruins) area."""
 # Note: Instead of checking for hammer-levels, these edges check for a custom RandomizerFlag "RF_ISK09_OpenedHammerChest".
 #       This is because the hammer blocks in here change depending on wether or not the hammer chest in Mt. Lavalava was opened beforehand.
@@ -16,7 +14,7 @@ edges_isk = [
     {"from": {"map": "ISK_02", "id": 1}, "to": {"map": "ISK_03", "id": 0}, "reqs": []}, # Sarcophagus Hall 1 Exit Top Right -> Sand Drainage Room 1 Exit Upper Room Left
     {"from": {"map": "ISK_02", "id": 2}, "to": {"map": "ISK_03", "id": 1}, "reqs": []}, # Sarcophagus Hall 1 Exit Bottom Right -> Sand Drainage Room 1 Exit Lower Room Left
     
-    {"from": {"map": "ISK_02", "id": 0}, "to": {"map": "ISK_02", "id": 1}, "reqs": [require(item="RuinsKey")]}, #? Sarcophagus Hall 1 Exit Left -> Sarcophagus Hall 1 Exit Top Right
+    {"from": {"map": "ISK_02", "id": 0}, "to": {"map": "ISK_02", "id": 1}, "reqs": [[{"RuinsKey": 1}]]}, #? Sarcophagus Hall 1 Exit Left -> Sarcophagus Hall 1 Exit Top Right
     {"from": {"map": "ISK_02", "id": 1}, "to": {"map": "ISK_02", "id": 0}, "reqs": []}, #? Sarcophagus Hall 1 Exit Top Right -> Sarcophagus Hall 1 Exit Left
     {"from": {"map": "ISK_02", "id": 0}, "to": {"map": "ISK_02", "id": 2}, "reqs": []}, #? Sarcophagus Hall 1 Exit Left -> Sarcophagus Hall 1 Exit Bottom Right
     {"from": {"map": "ISK_02", "id": 2}, "to": {"map": "ISK_02", "id": 0}, "reqs": []}, #? Sarcophagus Hall 1 Exit Bottom Right -> Sarcophagus Hall 1 Exit Top Right
@@ -29,7 +27,7 @@ edges_isk = [
     {"from": {"map": "ISK_03", "id": 1}, "to": {"map": "ISK_02", "id": 2}, "reqs": []}, # Sand Drainage Room 1 Exit Lower Room Left -> Sarcophagus Hall 1 Exit Bottom Right
     {"from": {"map": "ISK_03", "id": 2}, "to": {"map": "ISK_04", "id": 0}, "reqs": []}, # Sand Drainage Room 1 Exit Lower Room Right -> Descending Stairs 1 Exit Middle Left
     
-    {"from": {"map": "ISK_03", "id": 1}, "to": {"map": "ISK_03", "id": 2}, "reqs": [require(flag="MF_ISK03_DrainedFirstSandRoom")]}, #? Sand Drainage Room 1 Exit Lower Room Left -> Sand Drainage Room 1 Exit Lower Room Right
+    {"from": {"map": "ISK_03", "id": 1}, "to": {"map": "ISK_03", "id": 2}, "reqs": [["MF_ISK03_DrainedFirstSandRoom"]]}, #? Sand Drainage Room 1 Exit Lower Room Left -> Sand Drainage Room 1 Exit Lower Room Right
     {"from": {"map": "ISK_03", "id": 2}, "to": {"map": "ISK_03", "id": 1}, "reqs": []}, #? Sand Drainage Room 1 Exit Lower Room Right -> Sand Drainage Room 1 Exit Lower Room Left
     
     {"from": {"map": "ISK_03", "id": 0}, "to": {"map": "ISK_03", "id": 0}, "reqs": [], "pseudoitems": ["MF_ISK03_DrainedFirstSandRoom"]}, #+ Sand Drainage Room 1 Exit Upper Room Left
@@ -44,9 +42,9 @@ edges_isk = [
     {"from": {"map": "ISK_04", "id": 3}, "to": {"map": "ISK_06", "id": 1}, "reqs": []}, # Descending Stairs 1 Exit Middle Right -> Sand Drainage Room 2 Exit Lower Room Left
     {"from": {"map": "ISK_04", "id": 4}, "to": {"map": "ISK_05", "id": 0}, "reqs": []}, # Descending Stairs 1 Exit Bottom Right -> Pyramid Stone Room Exit Left
     
-    {"from": {"map": "ISK_04", "id": 0}, "to": {"map": "ISK_04", "id": 1}, "reqs": [require(item="RuinsKey")]}, #? Descending Stairs 1 Exit Middle Left -> Descending Stairs 1 Exit Bottom Left
+    {"from": {"map": "ISK_04", "id": 0}, "to": {"map": "ISK_04", "id": 1}, "reqs": [[{"RuinsKey": 2}]]}, #? Descending Stairs 1 Exit Middle Left -> Descending Stairs 1 Exit Bottom Left
     {"from": {"map": "ISK_04", "id": 1}, "to": {"map": "ISK_04", "id": 0}, "reqs": []}, #? Descending Stairs 1 Exit Bottom Left -> Descending Stairs 1 Exit Middle Left
-    {"from": {"map": "ISK_04", "id": 0}, "to": {"map": "ISK_04", "id": 2}, "reqs": [require(partner="Parakarry"), require(partner="Bombette")]}, #? Descending Stairs 1 Exit Middle Left -> Descending Stairs 1 Exit Top Right Cracked Wall
+    {"from": {"map": "ISK_04", "id": 0}, "to": {"map": "ISK_04", "id": 2}, "reqs": [["Parakarry"], ["Bombette"]]}, #? Descending Stairs 1 Exit Middle Left -> Descending Stairs 1 Exit Top Right Cracked Wall
     {"from": {"map": "ISK_04", "id": 2}, "to": {"map": "ISK_04", "id": 0}, "reqs": []}, #? Descending Stairs 1 Exit Top Right Cracked Wall -> Descending Stairs 1 Exit Middle Left
     {"from": {"map": "ISK_04", "id": 0}, "to": {"map": "ISK_04", "id": 3}, "reqs": []}, #? Descending Stairs 1 Exit Middle Left -> Descending Stairs 1 Exit Middle Right
     {"from": {"map": "ISK_04", "id": 3}, "to": {"map": "ISK_04", "id": 0}, "reqs": []}, #? Descending Stairs 1 Exit Middle Right -> Descending Stairs 1 Exit Middle Left
@@ -56,16 +54,16 @@ edges_isk = [
     # ISK_05 Pyramid Stone Room
     {"from": {"map": "ISK_05", "id": 0}, "to": {"map": "ISK_04", "id": 4}, "reqs": []}, # Pyramid Stone Room Exit Left -> Descending Stairs 1 Exit Bottom Right
     
-    {"from": {"map": "ISK_05", "id": 0},       "to": {"map": "ISK_05", "id": "ItemA"}, "reqs": [require(flag="RF_ISK09_OpenedHammerChest")]}, #* Pyramid Stone Room Exit Left -> ItemA (PyramidStone)
+    {"from": {"map": "ISK_05", "id": 0},       "to": {"map": "ISK_05", "id": "ItemA"}, "reqs": [["RF_ISK09_OpenedHammerChest"]]}, #* Pyramid Stone Room Exit Left -> ItemA (PyramidStone)
     {"from": {"map": "ISK_05", "id": "ItemA"}, "to": {"map": "ISK_05", "id": 0},       "reqs": []}, #* ItemA (PyramidStone) -> Pyramid Stone Room Exit Left
 
     # ISK_06 Sand Drainage Room 2
     {"from": {"map": "ISK_06", "id": 0}, "to": {"map": "ISK_04", "id": 2}, "reqs": []}, # Sand Drainage Room 2 Exit Upper Room Left -> Descending Stairs 1 Exit Top Right Cracked Wall
     {"from": {"map": "ISK_06", "id": 1}, "to": {"map": "ISK_04", "id": 3}, "reqs": []}, # Sand Drainage Room 2 Exit Lower Room Left -> Descending Stairs 1 Exit Middle Right
 
-    {"from": {"map": "ISK_06", "id": 0},       "to": {"map": "ISK_06", "id": "ItemA"}, "reqs": [require(flag="MF_ISK06_DrainedSecondSandRoom")]}, #* Sand Drainage Room 2 Exit Upper Room Left -> ItemA (StarPiece)
+    {"from": {"map": "ISK_06", "id": 0},       "to": {"map": "ISK_06", "id": "ItemA"}, "reqs": [["MF_ISK06_DrainedSecondSandRoom"]]}, #* Sand Drainage Room 2 Exit Upper Room Left -> ItemA (StarPiece)
     {"from": {"map": "ISK_06", "id": "ItemA"}, "to": {"map": "ISK_06", "id": 0},       "reqs": []}, #* ItemA (StarPiece) -> Sand Drainage Room 2 Exit Upper Room Left
-    {"from": {"map": "ISK_06", "id": 1},       "to": {"map": "ISK_06", "id": "ItemB"}, "reqs": [require(flag="MF_ISK06_DrainedSecondSandRoom")]}, #* Sand Drainage Room 2 Exit Lower Room Left -> ItemB (RuinsKey)
+    {"from": {"map": "ISK_06", "id": 1},       "to": {"map": "ISK_06", "id": "ItemB"}, "reqs": [["MF_ISK06_DrainedSecondSandRoom"]]}, #* Sand Drainage Room 2 Exit Lower Room Left -> ItemB (RuinsKey)
     {"from": {"map": "ISK_06", "id": "ItemB"}, "to": {"map": "ISK_06", "id": 1},       "reqs": []}, #* ItemB (RuinsKey) -> Sand Drainage Room 2 Exit Lower Room Left
     
     {"from": {"map": "ISK_06", "id": 0}, "to": {"map": "ISK_06", "id": 0}, "reqs": [], "pseudoitems": ["MF_ISK06_DrainedSecondSandRoom"]}, #+ Sand Drainage Room 2 Exit Upper Room Left
@@ -75,11 +73,11 @@ edges_isk = [
     {"from": {"map": "ISK_07", "id": 1}, "to": {"map": "ISK_04", "id": 1}, "reqs": []}, # Sarcophagus Hall 2 Exit Right -> Descending Stairs 1 Exit Bottom Left
     
     {"from": {"map": "ISK_07", "id": 0}, "to": {"map": "ISK_07", "id": 1}, "reqs": []}, #? Sarcophagus Hall 2 Exit Left -> Sarcophagus Hall 2 Exit Right
-    {"from": {"map": "ISK_07", "id": 1}, "to": {"map": "ISK_07", "id": 0}, "reqs": [require(item="RuinsKey")]}, #? Sarcophagus Hall 2 Exit Right -> Sarcophagus Hall 2 Exit Left
+    {"from": {"map": "ISK_07", "id": 1}, "to": {"map": "ISK_07", "id": 0}, "reqs": [[{"RuinsKey": 3}]]}, #? Sarcophagus Hall 2 Exit Right -> Sarcophagus Hall 2 Exit Left
     
     {"from": {"map": "ISK_07", "id": 1},       "to": {"map": "ISK_07", "id": "ItemA"}, "reqs": []}, #* Sarcophagus Hall 2 Exit Right -> ItemA (RuinsKey)
     {"from": {"map": "ISK_07", "id": "ItemA"}, "to": {"map": "ISK_07", "id": 1},       "reqs": []}, #* ItemA (RuinsKey) -> Sarcophagus Hall 2 Exit Right
-    {"from": {"map": "ISK_07", "id": 1},       "to": {"map": "ISK_07", "id": "ItemB"}, "reqs": [require(flag="RF_ISK09_OpenedHammerChest")]}, #* Sarcophagus Hall 2 Exit Right -> ItemB (Artifact)
+    {"from": {"map": "ISK_07", "id": 1},       "to": {"map": "ISK_07", "id": "ItemB"}, "reqs": [["RF_ISK09_OpenedHammerChest"]]}, #* Sarcophagus Hall 2 Exit Right -> ItemB (Artifact)
     {"from": {"map": "ISK_07", "id": "ItemB"}, "to": {"map": "ISK_07", "id": 1},       "reqs": []}, #* ItemB (Artifact) -> Sarcophagus Hall 2 Exit Right
 
     # ISK_08 Descending Stairs 2
@@ -88,9 +86,9 @@ edges_isk = [
     {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_07", "id": 0}, "reqs": []}, # Descending Stairs 2 Exit Top Right -> Sarcophagus Hall 2 Exit Left
     {"from": {"map": "ISK_08", "id": 3}, "to": {"map": "ISK_11", "id": 0}, "reqs": []}, # Descending Stairs 2 Exit Bottom Right -> Stone Puzzle Room Exit Left
     
-    {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_08", "id": 0}, "reqs": [require(partner="Parakarry")]}, #? Descending Stairs 2 Exit Top Right -> Descending Stairs 2 Exit Top Left
+    {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_08", "id": 0}, "reqs": [["Parakarry"]]}, #? Descending Stairs 2 Exit Top Right -> Descending Stairs 2 Exit Top Left
     {"from": {"map": "ISK_08", "id": 0}, "to": {"map": "ISK_08", "id": 2}, "reqs": []}, #? Descending Stairs 2 Exit Top Left -> Descending Stairs 2 Exit Top Right
-    {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_08", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Descending Stairs 2 Exit Top Right -> Descending Stairs 2 Exit Bottom Left Cracked Wall
+    {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_08", "id": 1}, "reqs": [["Bombette"]]}, #? Descending Stairs 2 Exit Top Right -> Descending Stairs 2 Exit Bottom Left Cracked Wall
     {"from": {"map": "ISK_08", "id": 1}, "to": {"map": "ISK_08", "id": 2}, "reqs": []}, #? Descending Stairs 2 Exit Bottom Left Cracked Wall -> Descending Stairs 2 Exit Top Right
     {"from": {"map": "ISK_08", "id": 2}, "to": {"map": "ISK_08", "id": 3}, "reqs": []}, #? Descending Stairs 2 Exit Top Right -> Descending Stairs 2 Exit Bottom Right
     {"from": {"map": "ISK_08", "id": 3}, "to": {"map": "ISK_08", "id": 2}, "reqs": []}, #? Descending Stairs 2 Exit Bottom Right -> Descending Stairs 2 Exit Top Right
@@ -108,10 +106,10 @@ edges_isk = [
     {"from": {"map": "ISK_10", "id": 1}, "to": {"map": "ISK_14", "id": 0}, "reqs": []}, # Vertical Shaft Exit Bottom Left -> Diamond Stone Room Exit Right
     {"from": {"map": "ISK_10", "id": 2}, "to": {"map": "ISK_18", "id": 0}, "reqs": []}, # Vertical Shaft Exit Bottom Right -> Deep Tunnel Exit Left
     
-    {"from": {"map": "ISK_10", "id": 0}, "to": {"map": "ISK_10", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Vertical Shaft Exit Top Right -> Vertical Shaft Exit Bottom Left
-    {"from": {"map": "ISK_10", "id": 1}, "to": {"map": "ISK_10", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Vertical Shaft Exit Bottom Left -> Vertical Shaft Exit Top Right
+    {"from": {"map": "ISK_10", "id": 0}, "to": {"map": "ISK_10", "id": 1}, "reqs": [["Bombette"]]}, #? Vertical Shaft Exit Top Right -> Vertical Shaft Exit Bottom Left
+    {"from": {"map": "ISK_10", "id": 1}, "to": {"map": "ISK_10", "id": 0}, "reqs": [["Bombette"]]}, #? Vertical Shaft Exit Bottom Left -> Vertical Shaft Exit Top Right
     {"from": {"map": "ISK_10", "id": 0}, "to": {"map": "ISK_10", "id": 2}, "reqs": []}, #? Vertical Shaft Exit Top Right -> Vertical Shaft Exit Bottom Right
-    {"from": {"map": "ISK_10", "id": 2}, "to": {"map": "ISK_10", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Vertical Shaft Exit Bottom Right -> Vertical Shaft Exit Top Right
+    {"from": {"map": "ISK_10", "id": 2}, "to": {"map": "ISK_10", "id": 0}, "reqs": [["Bombette"]]}, #? Vertical Shaft Exit Bottom Right -> Vertical Shaft Exit Top Right
 
     # ISK_11 Stone Puzzle Room
     {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_08", "id": 3}, "reqs": []}, # Stone Puzzle Room Exit Left -> Descending Stairs 2 Exit Bottom Right
@@ -119,12 +117,12 @@ edges_isk = [
     {"from": {"map": "ISK_11", "id": 2}, "to": {"map": "ISK_12", "id": 1}, "reqs": []}, # Stone Puzzle Room Exit Bottom Right -> Sand Drainage Room 3 Exit Top Left
     {"from": {"map": "ISK_11", "id": 3}, "to": {"map": "ISK_19", "id": 0}, "reqs": []}, # Stone Puzzle Room Exit Hidden Stairway -> Boss Antechamber Exit Left
     
-    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 1}, "reqs": [require(item="RuinsKey")]}, #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Top Right
+    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 1}, "reqs": [[{"RuinsKey": 4}]]}, #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Top Right
     {"from": {"map": "ISK_11", "id": 1}, "to": {"map": "ISK_11", "id": 0}, "reqs": []}, #? Stone Puzzle Room Exit Top Right -> Stone Puzzle Room Exit Left
     {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 2}, "reqs": []}, #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Bottom Right
     {"from": {"map": "ISK_11", "id": 2}, "to": {"map": "ISK_11", "id": 0}, "reqs": []}, #? Stone Puzzle Room Exit Bottom Right -> Stone Puzzle Room Exit Left
-    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": [require(item="PyramidStone"), require(item="DiamondStone"), require(item="LunarStone")], "pseudoitems": ["MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle"]}, #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Hidden Stairway
-    {"from": {"map": "ISK_11", "id": 3}, "to": {"map": "ISK_11", "id": 0}, "reqs": [require(flag="MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle")]}, #? Stone Puzzle Room Exit Hidden Stairway -> Stone Puzzle Room Exit Left
+    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": [["PyramidStone"], ["DiamondStone"], ["LunarStone"]], "pseudoitems": ["MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle"]}, #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Hidden Stairway
+    {"from": {"map": "ISK_11", "id": 3}, "to": {"map": "ISK_11", "id": 0}, "reqs": [["MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle"]]}, #? Stone Puzzle Room Exit Hidden Stairway -> Stone Puzzle Room Exit Left
 
     # ISK_12 Sand Drainage Room 3
     {"from": {"map": "ISK_12", "id": 0}, "to": {"map": "ISK_11", "id": 1}, "reqs": []}, # Sand Drainage Room 3 Exit Upper Room Left -> Stone Puzzle Room Exit Top Right
@@ -132,34 +130,34 @@ edges_isk = [
     {"from": {"map": "ISK_12", "id": 2}, "to": {"map": "ISK_18", "id": 1}, "reqs": []}, # Sand Drainage Room 3 Exit Bottom Left -> Deep Tunnel Exit Right
     {"from": {"map": "ISK_12", "id": 3}, "to": {"map": "ISK_13", "id": 0}, "reqs": []}, # Sand Drainage Room 3 Exit Top Right -> Lunar Stone Room Exit Left
     
-    {"from": {"map": "ISK_12", "id": 1}, "to": {"map": "ISK_12", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Sand Drainage Room 3 Exit Top Left -> Sand Drainage Room 3 Exit Bottom Left
-    {"from": {"map": "ISK_12", "id": 1}, "to": {"map": "ISK_12", "id": 3}, "reqs": [require(flag="MF_ISK12_DrainedThirdSandRoom")]}, #? Sand Drainage Room 3 Exit Top Left -> Sand Drainage Room 3 Exit Top Right
-    {"from": {"map": "ISK_12", "id": 3}, "to": {"map": "ISK_12", "id": 1}, "reqs": [require(flag="MF_ISK12_DrainedThirdSandRoom")]}, #? Sand Drainage Room 3 Exit Top Right -> Sand Drainage Room 3 Exit Top Left
-    {"from": {"map": "ISK_12", "id": 3}, "to": {"map": "ISK_12", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Sand Drainage Room 3 Exit Top Right -> Sand Drainage Room 3 Exit Bottom Left
+    {"from": {"map": "ISK_12", "id": 1}, "to": {"map": "ISK_12", "id": 2}, "reqs": [["Bombette"]]}, #? Sand Drainage Room 3 Exit Top Left -> Sand Drainage Room 3 Exit Bottom Left
+    {"from": {"map": "ISK_12", "id": 1}, "to": {"map": "ISK_12", "id": 3}, "reqs": [["MF_ISK12_DrainedThirdSandRoom"]]}, #? Sand Drainage Room 3 Exit Top Left -> Sand Drainage Room 3 Exit Top Right
+    {"from": {"map": "ISK_12", "id": 3}, "to": {"map": "ISK_12", "id": 1}, "reqs": [["MF_ISK12_DrainedThirdSandRoom"]]}, #? Sand Drainage Room 3 Exit Top Right -> Sand Drainage Room 3 Exit Top Left
+    {"from": {"map": "ISK_12", "id": 3}, "to": {"map": "ISK_12", "id": 2}, "reqs": [["Bombette"]]}, #? Sand Drainage Room 3 Exit Top Right -> Sand Drainage Room 3 Exit Bottom Left
     
     {"from": {"map": "ISK_12", "id": 0}, "to": {"map": "ISK_12", "id": 0}, "reqs": [], "pseudoitems": ["MF_ISK12_DrainedThirdSandRoom"]}, #+ Sand Drainage Room 3 Exit Upper Room Left
     
-    {"from": {"map": "ISK_12", "id": 2},       "to": {"map": "ISK_12", "id": "ItemA"}, "reqs": [require(flag="RF_ISK09_OpenedHammerChest")]}, #* Sand Drainage Room 3 Exit Bottom Left -> ItemA (RuinsKey)
+    {"from": {"map": "ISK_12", "id": 2},       "to": {"map": "ISK_12", "id": "ItemA"}, "reqs": [["RF_ISK09_OpenedHammerChest"]]}, #* Sand Drainage Room 3 Exit Bottom Left -> ItemA (RuinsKey)
     {"from": {"map": "ISK_12", "id": "ItemA"}, "to": {"map": "ISK_12", "id": 2},       "reqs": []}, #* ItemA (RuinsKey) -> Sand Drainage Room 3 Exit Bottom Left
     {"from": {"map": "ISK_12", "id": 3},       "to": {"map": "ISK_12", "id": "ItemA"}, "reqs": []}, #* Sand Drainage Room 3 Exit Top Right -> ItemA (RuinsKey)
-    {"from": {"map": "ISK_12", "id": "ItemA"}, "to": {"map": "ISK_12", "id": 3},       "reqs": [require(flag="MF_ISK12_DrainedThirdSandRoom")]}, #* ItemA (RuinsKey) -> Sand Drainage Room 3 Exit Top Right
+    {"from": {"map": "ISK_12", "id": "ItemA"}, "to": {"map": "ISK_12", "id": 3},       "reqs": [["MF_ISK12_DrainedThirdSandRoom"]]}, #* ItemA (RuinsKey) -> Sand Drainage Room 3 Exit Top Right
 
     # ISK_13 Lunar Stone Room
     {"from": {"map": "ISK_13", "id": 0}, "to": {"map": "ISK_12", "id": 3}, "reqs": []}, # Lunar Stone Room Exit Left -> Sand Drainage Room 3 Exit Top Right
 
-    {"from": {"map": "ISK_13", "id": 0},       "to": {"map": "ISK_13", "id": "ItemA"}, "reqs": [require(flag="RF_ISK09_OpenedHammerChest")]}, #* Lunar Stone Room Exit Left -> ItemA (LunarStone)
+    {"from": {"map": "ISK_13", "id": 0},       "to": {"map": "ISK_13", "id": "ItemA"}, "reqs": [["RF_ISK09_OpenedHammerChest"]]}, #* Lunar Stone Room Exit Left -> ItemA (LunarStone)
     {"from": {"map": "ISK_13", "id": "ItemA"}, "to": {"map": "ISK_13", "id": 0},       "reqs": []}, #* ItemA (LunarStone) -> Lunar Stone Room Exit Left
 
     # ISK_14 Diamond Stone Room
     {"from": {"map": "ISK_14", "id": 0}, "to": {"map": "ISK_10", "id": 1}, "reqs": []}, # Diamond Stone Room Exit Right -> Vertical Shaft Exit Bottom Left
     
-    {"from": {"map": "ISK_14", "id": 0},       "to": {"map": "ISK_14", "id": "ItemA"}, "reqs": [require(flag="RF_ISK09_OpenedHammerChest")]}, #* Diamond Stone Room Exit Right -> ItemA (DiamondStone)
+    {"from": {"map": "ISK_14", "id": 0},       "to": {"map": "ISK_14", "id": "ItemA"}, "reqs": [["RF_ISK09_OpenedHammerChest"]]}, #* Diamond Stone Room Exit Right -> ItemA (DiamondStone)
     {"from": {"map": "ISK_14", "id": "ItemA"}, "to": {"map": "ISK_14", "id": 0},       "reqs": []}, #* ItemA (DiamondStone) -> Diamond Stone Room Exit Right
 
     # ISK_16 Tutankoopa Room
     {"from": {"map": "ISK_16", "id": 0}, "to": {"map": "ISK_19", "id": 1}, "reqs": []}, # Tutankoopa Room Exit Left -> Boss Antechamber Exit Right
     
-    {"from": {"map": "ISK_16", "id": 0}, "to": {"map": "ISK_16", "id": 0}, "reqs": [require(flag="MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle")], "pseudoitems": ["STARSPIRIT_2", "RF_Ch2_SavedStarSpirit"]}, #+ Tutankoopa Room Exit Left
+    {"from": {"map": "ISK_16", "id": 0}, "to": {"map": "ISK_16", "id": 0}, "reqs": [["MB_Ch2_Spirit_ISK11_SolvedArtifactPuzzle"]], "pseudoitems": ["STARSPIRIT_2", "RF_Ch2_SavedStarSpirit"]}, #+ Tutankoopa Room Exit Left
 
     # ISK_18 Deep Tunnel
     {"from": {"map": "ISK_18", "id": 0}, "to": {"map": "ISK_10", "id": 2}, "reqs": []}, # Deep Tunnel Exit Left -> Vertical Shaft Exit Bottom Right

--- a/maps/graph_edges/edges_iwa.py
+++ b/maps/graph_edges/edges_iwa.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the IWA (Mt. Rugged) area."""
 edges_iwa = [
     # IWA_00 Mt Rugged 1
@@ -15,7 +13,7 @@ edges_iwa = [
     {"from": {"map": "IWA_00", "id": "ItemB"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemB (Coin) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemC"},   "reqs": []}, #* Mt Rugged 1 Exit Left -> ItemC (Coin)
     {"from": {"map": "IWA_00", "id": "ItemC"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemC (Coin) -> Mt Rugged 1 Exit Left
-    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [require(hammer=1),require(flag="RF_Missable")]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
+    {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "ItemD"},   "reqs": [["Hammer"],["RF_Missable"]]}, #* Mt Rugged 1 Exit Left -> ItemD (WhackasBump)
     {"from": {"map": "IWA_00", "id": "ItemD"},   "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* ItemD (WhackasBump) -> Mt Rugged 1 Exit Left
     {"from": {"map": "IWA_00", "id": 0},         "to": {"map": "IWA_00", "id": "YBlockA"}, "reqs": []}, #* Mt Rugged 1 Exit Left -> YBlockA (SleepySheep)
     {"from": {"map": "IWA_00", "id": "YBlockA"}, "to": {"map": "IWA_00", "id": 0},         "reqs": []}, #* YBlockA (SleepySheep) -> Mt Rugged 1 Exit Left
@@ -31,11 +29,11 @@ edges_iwa = [
     {"from": {"map": "IWA_01", "id": 3}, "to": {"map": "IWA_01", "id": 1}, "reqs": []}, #? Mt Rugged 2 Exit Top Right -> Mt Rugged 2 Exit Top Left
     {"from": {"map": "IWA_01", "id": 1}, "to": {"map": "IWA_01", "id": 0}, "reqs": []}, #? Mt Rugged 2 Exit Top Left -> Mt Rugged 2 Exit Bottom Left
     
-    {"from": {"map": "IWA_01", "id": 0},             "to": {"map": "IWA_01", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Mt Rugged 2 Exit Bottom Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "IWA_01", "id": 0},             "to": {"map": "IWA_01", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Mt Rugged 2 Exit Bottom Left -> HiddenPanel (StarPiece)
     {"from": {"map": "IWA_01", "id": "HiddenPanel"}, "to": {"map": "IWA_01", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Mt Rugged 2 Exit Bottom Left
-    {"from": {"map": "IWA_01", "id": "ItemB"},       "to": {"map": "IWA_01", "id": "ItemA"},       "reqs": [require(partner="Parakarry")]}, #* ItemB (Letter01) -> ItemA (QuakeHammer)
+    {"from": {"map": "IWA_01", "id": "ItemB"},       "to": {"map": "IWA_01", "id": "ItemA"},       "reqs": [["Parakarry"]]}, #* ItemB (Letter01) -> ItemA (QuakeHammer)
     {"from": {"map": "IWA_01", "id": "ItemA"},       "to": {"map": "IWA_01", "id": "ItemB"},       "reqs": []}, #* ItemA (QuakeHammer) -> ItemB (Letter01)
-    {"from": {"map": "IWA_01", "id": 0},             "to": {"map": "IWA_01", "id": "ItemB"},       "reqs": [require(partner=["Kooper","Parakarry"])]}, #* Mt Rugged 2 Exit Bottom Left -> ItemB (Letter01)
+    {"from": {"map": "IWA_01", "id": 0},             "to": {"map": "IWA_01", "id": "ItemB"},       "reqs": [["Kooper","Parakarry"]]}, #* Mt Rugged 2 Exit Bottom Left -> ItemB (Letter01)
     {"from": {"map": "IWA_01", "id": "ItemB"},       "to": {"map": "IWA_01", "id": 0},             "reqs": []}, #* ItemB (Letter01) -> Mt Rugged 2 Exit Bottom Left
 
     # IWA_02 Mt Rugged 3
@@ -48,7 +46,7 @@ edges_iwa = [
     {"from": {"map": "IWA_02", "id": 0}, "to": {"map": "IWA_02", "id": 2}, "reqs": []}, #? Mt Rugged 3 Exit Bottom Left -> Mt Rugged 3 Exit Top Right
     {"from": {"map": "IWA_02", "id": 2}, "to": {"map": "IWA_02", "id": 0}, "reqs": []}, #? Mt Rugged 3 Exit Top Right -> Mt Rugged 3 Exit Bottom Left
     
-    {"from": {"map": "IWA_02", "id": 0},       "to": {"map": "IWA_02", "id": "GiftA"}, "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 3 Exit Bottom Left -> GiftA (MagicalSeed2)
+    {"from": {"map": "IWA_02", "id": 0},       "to": {"map": "IWA_02", "id": "GiftA"}, "reqs": [["Parakarry"]]}, #* Mt Rugged 3 Exit Bottom Left -> GiftA (MagicalSeed2)
     {"from": {"map": "IWA_02", "id": "GiftA"}, "to": {"map": "IWA_02", "id": 0},       "reqs": []}, #* GiftA (MagicalSeed2) -> Mt Rugged 3 Exit Bottom Left
     {"from": {"map": "IWA_02", "id": 0},       "to": {"map": "IWA_02", "id": "ItemA"}, "reqs": []}, #* Mt Rugged 3 Exit Bottom Left -> ItemA (StarPiece)
     {"from": {"map": "IWA_02", "id": "ItemA"}, "to": {"map": "IWA_02", "id": 0},       "reqs": []}, #* ItemA (StarPiece) -> Mt Rugged 3 Exit Bottom Left
@@ -60,36 +58,36 @@ edges_iwa = [
     {"from": {"map": "IWA_03", "id": "ChestA"},  "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ChestA (DamageDodgeB) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemA"},   "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> ItemA (Letter25)
     {"from": {"map": "IWA_03", "id": "ItemA"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemA (Letter25) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemB"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemB (StarPiece)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemB"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemB (StarPiece)
     {"from": {"map": "IWA_03", "id": "ItemB"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemB (StarPiece) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemC"},   "reqs": [require(partner=["Kooper","Parakarry"])]}, #* Mt Rugged 4 Exit Bottom Right -> ItemC (Coin) (circle-right)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemC"},   "reqs": [["Kooper","Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemC (Coin) (circle-right)
     {"from": {"map": "IWA_03", "id": "ItemC"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemC (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemD"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemD (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemD"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemD (Coin)
     {"from": {"map": "IWA_03", "id": "ItemD"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemD (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemE"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemE (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemE"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemE (Coin)
     {"from": {"map": "IWA_03", "id": "ItemE"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemE (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemF"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemF (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemF"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemF (Coin)
     {"from": {"map": "IWA_03", "id": "ItemF"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemF (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemG"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemG (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemG"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemG (Coin)
     {"from": {"map": "IWA_03", "id": "ItemG"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemG (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemH"},   "reqs": [require(partner="Parakarry")]}, #* Mt Rugged 4 Exit Bottom Right -> ItemH (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemH"},   "reqs": [["Parakarry"]]}, #* Mt Rugged 4 Exit Bottom Right -> ItemH (Coin)
     {"from": {"map": "IWA_03", "id": "ItemH"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemH (Coin) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemI"},   "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> ItemI (Coin) (bottom1)
     {"from": {"map": "IWA_03", "id": "ItemI"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemI (Coin) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "ItemJ"},   "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> ItemJ (Coin) (bottom2)
     {"from": {"map": "IWA_03", "id": "ItemJ"},   "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* ItemJ (Coin) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockA (Coin)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockA (Coin)
     {"from": {"map": "IWA_03", "id": "YBlockA"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Mt Rugged 4 Exit Bottom Right
     {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockB"}, "reqs": []}, #* Mt Rugged 4 Exit Bottom Right -> YBlockB (Mushroom)
     {"from": {"map": "IWA_03", "id": "YBlockB"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockB (Mushroom) -> Mt Rugged 4 Exit Bottom Right
-    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockC (HoneySyrup)
+    {"from": {"map": "IWA_03", "id": 0},         "to": {"map": "IWA_03", "id": "YBlockC"}, "reqs": [["can_hit_grounded_blocks"]]}, #* Mt Rugged 4 Exit Bottom Right -> YBlockC (HoneySyrup)
     {"from": {"map": "IWA_03", "id": "YBlockC"}, "to": {"map": "IWA_03", "id": 0},         "reqs": []}, #* YBlockC (HoneySyrup) -> Mt Rugged 4 Exit Bottom Right
 
     # IWA_04 Suspension Bridge
     {"from": {"map": "IWA_04", "id": 0}, "to": {"map": "IWA_02", "id": 2}, "reqs": []}, # Suspension Bridge Exit Left -> Mt Rugged 3 Exit Top Right
     {"from": {"map": "IWA_04", "id": 1}, "to": {"map": "SBK_99", "id": 0}, "reqs": []}, # Suspension Bridge Exit Right -> Entrance Exit Left
     
-    {"from": {"map": "IWA_04", "id": 0}, "to": {"map": "IWA_04", "id": 1}, "reqs": [require(partner="Parakarry")]}, #? Suspension Bridge Exit Left -> Suspension Bridge Exit Right
+    {"from": {"map": "IWA_04", "id": 0}, "to": {"map": "IWA_04", "id": 1}, "reqs": [["Parakarry"]]}, #? Suspension Bridge Exit Left -> Suspension Bridge Exit Right
     {"from": {"map": "IWA_04", "id": 1}, "to": {"map": "IWA_04", "id": 0}, "reqs": []}, #? Suspension Bridge Exit Right -> Suspension Bridge Exit Left
     
     {"from": {"map": "IWA_04", "id": 0},       "to": {"map": "IWA_04", "id": "ItemA"}, "reqs": []}, #* Suspension Bridge Exit Left -> ItemA (Letter10)
@@ -110,7 +108,7 @@ edges_iwa = [
     {"from": {"map": "IWA_10", "id": "Bush3_Drop1"}, "to": {"map": "IWA_10", "id": 1},             "reqs": []}, #* Bush3_Drop1 (Coin) Left Bush -> Train Station Exit Top Right
     {"from": {"map": "IWA_10", "id": 1},             "to": {"map": "IWA_10", "id": "Bush4_Drop1"}, "reqs": []}, #* Train Station Exit Top Right -> Bush4_Drop1 (Egg2) Top Bush
     {"from": {"map": "IWA_10", "id": "Bush4_Drop1"}, "to": {"map": "IWA_10", "id": 1},             "reqs": []}, #* Bush4_Drop1 (Egg2) Top Bush -> Train Station Exit Top Right
-    {"from": {"map": "IWA_10", "id": 1},             "to": {"map": "IWA_10", "id": "Partner"},     "reqs": [has_parakarry_3_letters]}, #* Train Station Exit Top Right -> Partner (Parakarry)
+    {"from": {"map": "IWA_10", "id": 1},             "to": {"map": "IWA_10", "id": "Partner"},     "reqs": [["has_parakarry_letters"]]}, #* Train Station Exit Top Right -> Partner (Parakarry)
     {"from": {"map": "IWA_10", "id": "Partner"},     "to": {"map": "IWA_10", "id": 1},             "reqs": []}, #* Partner (Parakarry) -> Train Station Exit Top Right
 
     # IWA_11 Train Ride Scene

--- a/maps/graph_edges/edges_jan.py
+++ b/maps/graph_edges/edges_jan.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the JAN (Jade Jungle) area."""
 edges_jan = [
     # JAN_00 Whale Cove
@@ -18,7 +16,7 @@ edges_jan = [
     {"from": {"map": "JAN_00", "id": "ItemB"},        "to": {"map": "JAN_00", "id": 0},              "reqs": []}, #* ItemB (Coin) -> Whale Cove Ride The Whale
     {"from": {"map": "JAN_00", "id": 0},              "to": {"map": "JAN_00", "id": "ItemC"},        "reqs": []}, #* Whale Cove Ride The Whale -> ItemC (StopWatch)
     {"from": {"map": "JAN_00", "id": "ItemC"},        "to": {"map": "JAN_00", "id": 0},              "reqs": []}, #* ItemC (StopWatch) -> Whale Cove Ride The Whale
-    {"from": {"map": "JAN_00", "id": 0},              "to": {"map": "JAN_00", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* Whale Cove Ride The Whale -> Tree1_Drop1A (Coconut)
+    {"from": {"map": "JAN_00", "id": 0},              "to": {"map": "JAN_00", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Whale Cove Ride The Whale -> Tree1_Drop1A (Coconut)
     {"from": {"map": "JAN_00", "id": "Tree1_Drop1A"}, "to": {"map": "JAN_00", "id": 0},              "reqs": []}, #* Tree1_Drop1A (Coconut) -> Whale Cove Ride The Whale
 
     # JAN_01 Beach
@@ -34,23 +32,23 @@ edges_jan = [
     {"from": {"map": "JAN_01", "id": "ItemB"},         "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* ItemB (Coin) -> Beach Exit Left
     {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "ItemC"},         "reqs": []}, #* Beach Exit Left -> ItemC (Coin)
     {"from": {"map": "JAN_01", "id": "ItemC"},         "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* ItemC (Coin) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Beach Exit Left -> HiddenYBlockA (RepelGel)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Beach Exit Left -> HiddenYBlockA (RepelGel)
     {"from": {"map": "JAN_01", "id": "HiddenYBlockA"}, "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* HiddenYBlockA (RepelGel) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Beach Exit Left -> HiddenYBlockB (Mystery)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockB"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Beach Exit Left -> HiddenYBlockB (Mystery)
     {"from": {"map": "JAN_01", "id": "HiddenYBlockB"}, "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* HiddenYBlockB (Mystery) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree2_Drop1"},   "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree2_Drop1 (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree2_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree2_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree2_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree2_Drop1 (Coconut) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree3_Drop1"},   "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree3_Drop1 (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree3_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree3_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree3_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree3_Drop1 (Coconut) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree4_Drop1"},   "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree4_Drop1 (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree4_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree4_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree4_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree4_Drop1 (Coconut) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree5_Drop1"},   "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree5_Drop1 (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree5_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree5_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree5_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree5_Drop1 (Coconut) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree6_Drop1"},   "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree6_Drop1 (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree6_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree6_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree6_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree6_Drop1 (Coconut) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree7_Drop1A"},  "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree7_Drop1A (StarPiece)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree7_Drop1A"},  "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree7_Drop1A (StarPiece)
     {"from": {"map": "JAN_01", "id": "Tree7_Drop1A"},  "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree7_Drop1A (StarPiece) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree7_Drop1B"},  "reqs": [can_shake_trees]}, #* Beach Exit Left -> Tree7_Drop1B (Coconut)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree7_Drop1B"},  "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree7_Drop1B (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree7_Drop1B"},  "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree7_Drop1B (Coconut) -> Beach Exit Left
 
     # JAN_02 Village Cove
@@ -60,13 +58,13 @@ edges_jan = [
     {"from": {"map": "JAN_02", "id": 0}, "to": {"map": "JAN_02", "id": 1}, "reqs": []}, #? Village Cove Exit Top Left -> Village Cove Exit Right
     {"from": {"map": "JAN_02", "id": 1}, "to": {"map": "JAN_02", "id": 0}, "reqs": []}, #? Village Cove Exit Right -> Village Cove Exit Top Left
 
-    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "HiddenPanel"},  "reqs": [can_flip_panels]}, #* Village Cove Exit Top Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "HiddenPanel"},  "reqs": [["can_flip_panels"]]}, #* Village Cove Exit Top Left -> HiddenPanel (StarPiece)
     {"from": {"map": "JAN_02", "id": "HiddenPanel"},  "to": {"map": "JAN_02", "id": 0},              "reqs": []}, #* HiddenPanel (StarPiece) -> Village Cove Exit Top Left
-    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "GiftA"},        "reqs": [saved_all_yoshikids]}, #* Village Cove Exit Top Left -> GiftA (JadeRaven)
+    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "GiftA"},        "reqs": [["saved_all_yoshikids"]]}, #* Village Cove Exit Top Left -> GiftA (JadeRaven)
     {"from": {"map": "JAN_02", "id": "GiftA"},        "to": {"map": "JAN_02", "id": 0},              "reqs": []}, #* GiftA (JadeRaven) -> Village Cove Exit Top Left
-    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "Tree2_Drop1A"}, "reqs": [can_shake_trees]}, #* Village Cove Exit Top Left -> Tree2_Drop1A (Coconut)
+    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "Tree2_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Village Cove Exit Top Left -> Tree2_Drop1A (Coconut)
     {"from": {"map": "JAN_02", "id": "Tree2_Drop1A"}, "to": {"map": "JAN_02", "id": 0},              "reqs": []}, #* Tree2_Drop1A (Coconut) -> Village Cove Exit Top Left
-    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "Tree3_Drop1A"}, "reqs": [can_shake_trees]}, #* Village Cove Exit Top Left -> Tree3_Drop1A (Coconut)
+    {"from": {"map": "JAN_02", "id": 0},              "to": {"map": "JAN_02", "id": "Tree3_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Village Cove Exit Top Left -> Tree3_Drop1A (Coconut)
     {"from": {"map": "JAN_02", "id": "Tree3_Drop1A"}, "to": {"map": "JAN_02", "id": 0},              "reqs": []}, #* Tree3_Drop1A (Coconut) -> Village Cove Exit Top Left
 
     {"from": {"map": "JAN_02", "id": 0}, "to": {"map": "JAN_02", "id": 0}, "reqs": [], "pseudoitems": ["RF_YoshiKidsMissing"]}, #+ Village visited -> Yoshi Kids Missing
@@ -90,14 +88,14 @@ edges_jan = [
     {"from": {"map": "JAN_03", "id": 1}, "to": {"map": "JAN_03", "id": 0}, "reqs": []}, #? Village Buildings Exit Top Left -> Village Buildings Exit Left
     {"from": {"map": "JAN_03", "id": 0}, "to": {"map": "JAN_03", "id": 2}, "reqs": []}, #? Village Buildings Exit Left -> Village Buildings Exit Right
     {"from": {"map": "JAN_03", "id": 2}, "to": {"map": "JAN_03", "id": 0}, "reqs": []}, #? Village Buildings Exit Right -> Village Buildings Exit Left
-    {"from": {"map": "JAN_03", "id": 0}, "to": {"map": "JAN_03", "id": 3}, "reqs": [require(flag="GF_TIK08_WarpPipe")]}, #? Village Buildings Exit Left -> Village Buildings Blue Warp Pipe
+    {"from": {"map": "JAN_03", "id": 0}, "to": {"map": "JAN_03", "id": 3}, "reqs": [["GF_TIK08_WarpPipe"]]}, #? Village Buildings Exit Left -> Village Buildings Blue Warp Pipe
     {"from": {"map": "JAN_03", "id": 3}, "to": {"map": "JAN_03", "id": 0}, "reqs": []}, #? Village Buildings Blue Warp Pipe -> Village Buildings Exit Left
 
-    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "GiftA"},       "reqs": [saved_all_yoshikids,require(item="VolcanoVase"),require(flag="MF_Ch5_RescuedStarSpirit")]}, #* Village Buildings Exit Left -> GiftA (MagicalSeed4)
+    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "GiftA"},       "reqs": [["saved_all_yoshikids"],["VolcanoVase"],["MF_Ch5_RescuedStarSpirit"]]}, #* Village Buildings Exit Left -> GiftA (MagicalSeed4)
     {"from": {"map": "JAN_03", "id": "GiftA"},       "to": {"map": "JAN_03", "id": 0},             "reqs": []}, #* GiftA (MagicalSeed4) -> Village Buildings Exit Left
-    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "GiftB"},       "reqs": [saved_all_yoshikids,require(flag="RF_CanVisitTayceT")]}, #* Village Buildings Exit Left -> GiftB (Melon)
+    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "GiftB"},       "reqs": [["saved_all_yoshikids"],["RF_CanVisitTayceT"]]}, #* Village Buildings Exit Left -> GiftB (Melon)
     {"from": {"map": "JAN_03", "id": "GiftB"},       "to": {"map": "JAN_03", "id": 0},             "reqs": []}, #* GiftB (Melon) -> Village Buildings Exit Left
-    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "Tree1_Drop1A"},"reqs": [can_shake_trees]}, #* Village Buildings Exit Left -> Tree1_Drop1A (Coconut)
+    {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "Tree1_Drop1A"},"reqs": [["can_shake_trees"]]}, #* Village Buildings Exit Left -> Tree1_Drop1A (Coconut)
     {"from": {"map": "JAN_03", "id": "Tree1_Drop1A"},"to": {"map": "JAN_03", "id": 0},             "reqs": []}, #* Tree1_Drop1A (Coconut) -> Village Buildings Exit Left
     {"from": {"map": "JAN_03", "id": 0},             "to": {"map": "JAN_03", "id": "ShopItemA"},   "reqs": []}, #* Village Buildings Exit Left -> ShopItemA (SnowmanDoll)
     {"from": {"map": "JAN_03", "id": "ShopItemA"},   "to": {"map": "JAN_03", "id": 0},             "reqs": []}, #* ShopItemA (SnowmanDoll) -> Village Buildings Exit Left
@@ -126,13 +124,13 @@ edges_jan = [
     # JAN_04 Sushi Tree
     {"from": {"map": "JAN_04", "id": 0}, "to": {"map": "JAN_05", "id": 2}, "reqs": []}, # Sushi Tree Exit Left -> SE Jungle (Quake Hammer) Exit Right
 
-    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "ChestA"},       "reqs": [require(flag="MF_Ch5_RescuedStarSpirit")]}, #* Sushi Tree Exit Left -> ChestA (VolcanoVase)
+    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "ChestA"},       "reqs": [["MF_Ch5_RescuedStarSpirit"]]}, #* Sushi Tree Exit Left -> ChestA (VolcanoVase)
     {"from": {"map": "JAN_04", "id": "ChestA"},       "to": {"map": "JAN_04", "id": 0},              "reqs": []}, #* ChestA (VolcanoVase) -> Sushi Tree Exit Left
-    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "ItemA"},        "reqs": [require(partner="Sushie")]}, #* Sushi Tree Exit Left -> ItemA (StarPiece)
+    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "ItemA"},        "reqs": [["Sushie"]]}, #* Sushi Tree Exit Left -> ItemA (StarPiece)
     {"from": {"map": "JAN_04", "id": "ItemA"},        "to": {"map": "JAN_04", "id": 0},              "reqs": []}, #* ItemA (StarPiece) -> Sushi Tree Exit Left
-    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "Tree2_Drop1A"}, "reqs": [require(partner="Sushie"),can_shake_trees]}, #* Sushi Tree Exit Left -> Tree2_Drop1A (Letter04)
+    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "Tree2_Drop1A"}, "reqs": [["Sushie"],["can_shake_trees"]]}, #* Sushi Tree Exit Left -> Tree2_Drop1A (Letter04)
     {"from": {"map": "JAN_04", "id": "Tree2_Drop1A"}, "to": {"map": "JAN_04", "id": 0},              "reqs": []}, #* Tree2_Drop1A (Letter04) -> Sushi Tree Exit Left
-    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "Partner"},      "reqs": [can_shake_trees]}, #* Sushi Tree Exit Left -> Partner (Sushie)
+    {"from": {"map": "JAN_04", "id": 0},              "to": {"map": "JAN_04", "id": "Partner"},      "reqs": [["can_shake_trees"]]}, #* Sushi Tree Exit Left -> Partner (Sushie)
     {"from": {"map": "JAN_04", "id": "Partner"},      "to": {"map": "JAN_04", "id": 0},              "reqs": []}, #* Partner (Sushie) -> Sushi Tree Exit Left
 
     # JAN_05 SE Jungle (Quake Hammer)
@@ -141,17 +139,17 @@ edges_jan = [
     {"from": {"map": "JAN_05", "id": 2}, "to": {"map": "JAN_04", "id": 0}, "reqs": []}, # SE Jungle (Quake Hammer) Exit Right -> Sushi Tree Exit Left
     {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_06", "id": 0}, "reqs": []}, # SE Jungle (Quake Hammer) Exit Top -> NE Jungle (Raven Statue) Exit Bottom
 
-    {"from": {"map": "JAN_05", "id": 0}, "to": {"map": "JAN_05", "id": 1}, "reqs": [require(partner="Sushie")]}, #? SE Jungle (Quake Hammer) Exit Bottom Right -> SE Jungle (Quake Hammer) Exit Left
-    {"from": {"map": "JAN_05", "id": 1}, "to": {"map": "JAN_05", "id": 0}, "reqs": [require(partner="Sushie")]}, #? SE Jungle (Quake Hammer) Exit Left-> SE Jungle (Quake Hammer) Exit Bottom Right
+    {"from": {"map": "JAN_05", "id": 0}, "to": {"map": "JAN_05", "id": 1}, "reqs": [["Sushie"]]}, #? SE Jungle (Quake Hammer) Exit Bottom Right -> SE Jungle (Quake Hammer) Exit Left
+    {"from": {"map": "JAN_05", "id": 1}, "to": {"map": "JAN_05", "id": 0}, "reqs": [["Sushie"]]}, #? SE Jungle (Quake Hammer) Exit Left-> SE Jungle (Quake Hammer) Exit Bottom Right
     {"from": {"map": "JAN_05", "id": 0}, "to": {"map": "JAN_05", "id": 2}, "reqs": []}, #? SE Jungle (Quake Hammer) Exit Bottom Right -> SE Jungle (Quake Hammer) Exit Right
     {"from": {"map": "JAN_05", "id": 2}, "to": {"map": "JAN_05", "id": 0}, "reqs": []}, #? SE Jungle (Quake Hammer) Exit Right-> SE Jungle (Quake Hammer) Exit Bottom Right
-    {"from": {"map": "JAN_05", "id": 0}, "to": {"map": "JAN_05", "id": 3}, "reqs": [require(flag="GF_JAN05_CreateLogBridge")]}, #? SE Jungle (Quake Hammer) Exit Bottom Right -> SE Jungle (Quake Hammer) Exit Top
-    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 0}, "reqs": [require(hammer=1)], "pseudoitems": ["GF_JAN05_CreateLogBridge"]}, #? SE Jungle (Quake Hammer) Exit Top-> SE Jungle (Quake Hammer) Exit Bottom Right
+    {"from": {"map": "JAN_05", "id": 0}, "to": {"map": "JAN_05", "id": 3}, "reqs": [["GF_JAN05_CreateLogBridge"]]}, #? SE Jungle (Quake Hammer) Exit Bottom Right -> SE Jungle (Quake Hammer) Exit Top
+    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 0}, "reqs": [["Hammer"]], "pseudoitems": ["GF_JAN05_CreateLogBridge"]}, #? SE Jungle (Quake Hammer) Exit Top-> SE Jungle (Quake Hammer) Exit Bottom Right
 
-    {"from": {"map": "JAN_05", "id": 2},         "to": {"map": "JAN_05", "id": "RBlockA"}, "reqs": [require(partner="Sushie")]}, #* SE Jungle (Quake Hammer) Exit Right-> RBlockA (PowerQuake)
-    {"from": {"map": "JAN_05", "id": "RBlockA"}, "to": {"map": "JAN_05", "id": 2},         "reqs": [require(partner="Sushie")]}, #* RBlockA (PowerQuake) -> SE Jungle (Quake Hammer) Exit Right
+    {"from": {"map": "JAN_05", "id": 2},         "to": {"map": "JAN_05", "id": "RBlockA"}, "reqs": [["Sushie"]]}, #* SE Jungle (Quake Hammer) Exit Right-> RBlockA (PowerQuake)
+    {"from": {"map": "JAN_05", "id": "RBlockA"}, "to": {"map": "JAN_05", "id": 2},         "reqs": [["Sushie"]]}, #* RBlockA (PowerQuake) -> SE Jungle (Quake Hammer) Exit Right
 
-    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 3}, "reqs": [require(flag="RF_YoshiKidsMissing"),require(hammer=1)], "pseudoitems": ["RF_SavedYoshiKid_1"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_05", "id": 3}, "to": {"map": "JAN_05", "id": 3}, "reqs": [["RF_YoshiKidsMissing"],["Hammer"]], "pseudoitems": ["RF_SavedYoshiKid_1"]}, #+ Save Yoshi Kid
 
     # JAN_06 NE Jungle (Raven Statue)
     {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_05", "id": 3}, "reqs": []}, # NE Jungle (Raven Statue) Exit Bottom -> SE Jungle (Quake Hammer) Exit Top
@@ -159,41 +157,41 @@ edges_jan = [
     {"from": {"map": "JAN_06", "id": 2}, "to": {"map": "JAN_12", "id": 0}, "reqs": []}, # NE Jungle (Raven Statue) Exit Top -> Deep Jungle 1 Exit Bottom Left
     {"from": {"map": "JAN_06", "id": 3}, "to": {"map": "JAN_09", "id": 1}, "reqs": []}, # NE Jungle (Raven Statue) Exit Left -> NW Jungle (Large Ledge) Exit Right
 
-    {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_06", "id": 1}, "reqs": [require(partner="Sushie")]}, #? NE Jungle (Raven Statue) Exit Bottom -> NE Jungle (Raven Statue) Exit Right
-    {"from": {"map": "JAN_06", "id": 1}, "to": {"map": "JAN_06", "id": 0}, "reqs": [require(partner="Sushie")]}, #? NE Jungle (Raven Statue) Exit Right -> NE Jungle (Raven Statue) Exit Bottom
-    {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_06", "id": 2}, "reqs": [require(partner="Sushie"),require(item="JadeRaven")]}, #? NE Jungle (Raven Statue) Exit Bottom -> NE Jungle (Raven Statue) Exit Top
-    {"from": {"map": "JAN_06", "id": 2}, "to": {"map": "JAN_06", "id": 0}, "reqs": [require(partner="Sushie")]}, #? NE Jungle (Raven Statue) Exit Top -> NE Jungle (Raven Statue) Exit Bottom
-    {"from": {"map": "JAN_06", "id": 1}, "to": {"map": "JAN_06", "id": 3}, "reqs": [require(flag="GF_JAN06_CreateLogBridge")]}, #? NE Jungle (Raven Statue) Exit Right -> NE Jungle (Raven Statue) Exit Left
-    {"from": {"map": "JAN_06", "id": 3}, "to": {"map": "JAN_06", "id": 1}, "reqs": [require(hammer=1)], "pseudoitems": ["GF_JAN06_CreateLogBridge"]}, #? NE Jungle (Raven Statue) Exit Left -> NE Jungle (Raven Statue) Exit Right
+    {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_06", "id": 1}, "reqs": [["Sushie"]]}, #? NE Jungle (Raven Statue) Exit Bottom -> NE Jungle (Raven Statue) Exit Right
+    {"from": {"map": "JAN_06", "id": 1}, "to": {"map": "JAN_06", "id": 0}, "reqs": [["Sushie"]]}, #? NE Jungle (Raven Statue) Exit Right -> NE Jungle (Raven Statue) Exit Bottom
+    {"from": {"map": "JAN_06", "id": 0}, "to": {"map": "JAN_06", "id": 2}, "reqs": [["JadeRaven"],["Sushie"]]}, #? NE Jungle (Raven Statue) Exit Bottom -> NE Jungle (Raven Statue) Exit Top
+    {"from": {"map": "JAN_06", "id": 2}, "to": {"map": "JAN_06", "id": 0}, "reqs": [["Sushie"]]}, #? NE Jungle (Raven Statue) Exit Top -> NE Jungle (Raven Statue) Exit Bottom
+    {"from": {"map": "JAN_06", "id": 1}, "to": {"map": "JAN_06", "id": 3}, "reqs": [["GF_JAN06_CreateLogBridge"]]}, #? NE Jungle (Raven Statue) Exit Right -> NE Jungle (Raven Statue) Exit Left
+    {"from": {"map": "JAN_06", "id": 3}, "to": {"map": "JAN_06", "id": 1}, "reqs": [["Hammer"]], "pseudoitems": ["GF_JAN06_CreateLogBridge"]}, #? NE Jungle (Raven Statue) Exit Left -> NE Jungle (Raven Statue) Exit Right
 
-    {"from": {"map": "JAN_06", "id": 0},       "to": {"map": "JAN_06", "id": "ItemA"}, "reqs": [require(partner="Sushie")]}, #* NE Jungle (Raven Statue) Exit Bottom -> ItemA (Coin)
-    {"from": {"map": "JAN_06", "id": "ItemA"}, "to": {"map": "JAN_06", "id": 0},       "reqs": [require(partner="Sushie")]}, #* ItemA (Coin) -> NE Jungle (Raven Statue) Exit Bottom
+    {"from": {"map": "JAN_06", "id": 0},       "to": {"map": "JAN_06", "id": "ItemA"}, "reqs": [["Sushie"]]}, #* NE Jungle (Raven Statue) Exit Bottom -> ItemA (Coin)
+    {"from": {"map": "JAN_06", "id": "ItemA"}, "to": {"map": "JAN_06", "id": 0},       "reqs": [["Sushie"]]}, #* ItemA (Coin) -> NE Jungle (Raven Statue) Exit Bottom
 
     # JAN_07 Small Jungle Ledge
     {"from": {"map": "JAN_07", "id": 0}, "to": {"map": "JAN_06", "id": 1}, "reqs": []}, # Small Jungle Ledge Exit Left -> NE Jungle (Raven Statue) Exit Right
 
-    {"from": {"map": "JAN_07", "id": 0}, "to": {"map": "JAN_07", "id": 0}, "reqs": [require(flag="RF_YoshiKidsMissing")], "pseudoitems": ["RF_SavedYoshiKid_2"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_07", "id": 0}, "to": {"map": "JAN_07", "id": 0}, "reqs": [["RF_YoshiKidsMissing"]], "pseudoitems": ["RF_SavedYoshiKid_2"]}, #+ Save Yoshi Kid
 
     # JAN_08 SW Jungle (Super Block)
     {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_00", "id": 2}, "reqs": []}, # SW Jungle (Super Block) Exit Bottom Left -> Whale Cove Exit Top Right
     {"from": {"map": "JAN_08", "id": 1}, "to": {"map": "JAN_05", "id": 1}, "reqs": []}, # SW Jungle (Super Block) Exit Right -> SE Jungle (Quake Hammer) Exit Left
     {"from": {"map": "JAN_08", "id": 2}, "to": {"map": "JAN_09", "id": 0}, "reqs": []}, # SW Jungle (Super Block) Exit Top -> NW Jungle (Large Ledge) Exit Bottom
 
-    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 1}, "reqs": [require(partner="Sushie")]}, #? SW Jungle (Super Block) Exit Bottom Left -> SW Jungle (Super Block) Exit Right
-    {"from": {"map": "JAN_08", "id": 1}, "to": {"map": "JAN_08", "id": 0}, "reqs": [require(partner="Sushie")]}, #? SW Jungle (Super Block) Exit Right -> SW Jungle (Super Block) Exit Bottom Left
-    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 2}, "reqs": [require(partner="Sushie")]}, #? SW Jungle (Super Block) Exit Bottom Left -> SW Jungle (Super Block) Exit Top
-    {"from": {"map": "JAN_08", "id": 2}, "to": {"map": "JAN_08", "id": 0}, "reqs": [require(partner="Sushie")]}, #? SW Jungle (Super Block) Exit Top -> SW Jungle (Super Block) Exit Bottom Left
+    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 1}, "reqs": [["Sushie"]]}, #? SW Jungle (Super Block) Exit Bottom Left -> SW Jungle (Super Block) Exit Right
+    {"from": {"map": "JAN_08", "id": 1}, "to": {"map": "JAN_08", "id": 0}, "reqs": [["Sushie"]]}, #? SW Jungle (Super Block) Exit Right -> SW Jungle (Super Block) Exit Bottom Left
+    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 2}, "reqs": [["Sushie"]]}, #? SW Jungle (Super Block) Exit Bottom Left -> SW Jungle (Super Block) Exit Top
+    {"from": {"map": "JAN_08", "id": 2}, "to": {"map": "JAN_08", "id": 0}, "reqs": [["Sushie"]]}, #? SW Jungle (Super Block) Exit Top -> SW Jungle (Super Block) Exit Bottom Left
 
-    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemA"},         "reqs": [require(partner="Sushie")]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemA (Coin)
+    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemA"},         "reqs": [["Sushie"]]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemA (Coin)
     {"from": {"map": "JAN_08", "id": "ItemA"},         "to": {"map": "JAN_08", "id": 0},               "reqs": []}, #* ItemA (Coin) -> SW Jungle (Super Block) Exit Bottom Left
-    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemB"},         "reqs": [require(partner="Sushie")]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemB (Coin)
+    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemB"},         "reqs": [["Sushie"]]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemB (Coin)
     {"from": {"map": "JAN_08", "id": "ItemB"},         "to": {"map": "JAN_08", "id": 0},               "reqs": []}, #* ItemB (Coin) -> SW Jungle (Super Block) Exit Bottom Left
-    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemC"},         "reqs": [require(partner="Sushie")]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemC (Coin)
+    {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemC"},         "reqs": [["Sushie"]]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemC (Coin)
     {"from": {"map": "JAN_08", "id": "ItemC"},         "to": {"map": "JAN_08", "id": 0},               "reqs": []}, #* ItemC (Coin) -> SW Jungle (Super Block) Exit Bottom Left
-    {"from": {"map": "JAN_08", "id": 2},               "to": {"map": "JAN_08", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* SW Jungle (Super Block) Exit Top -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "JAN_08", "id": 2},               "to": {"map": "JAN_08", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* SW Jungle (Super Block) Exit Top -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "JAN_08", "id": "HiddenYBlockA"}, "to": {"map": "JAN_08", "id": 2},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> SW Jungle (Super Block) Exit Top
 
-    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 0}, "reqs": [require(flag="RF_YoshiKidsMissing")], "pseudoitems": ["RF_SavedYoshiKid_3"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 0}, "reqs": [["RF_YoshiKidsMissing"]], "pseudoitems": ["RF_SavedYoshiKid_3"]}, #+ Save Yoshi Kid
 
     # JAN_09 NW Jungle (Large Ledge)
     {"from": {"map": "JAN_09", "id": 0}, "to": {"map": "JAN_08", "id": 2}, "reqs": []}, # NW Jungle (Large Ledge) Exit Bottom -> SW Jungle (Super Block) Exit Top
@@ -203,32 +201,32 @@ edges_jan = [
 
     {"from": {"map": "JAN_09", "id": 0}, "to": {"map": "JAN_09", "id": 1}, "reqs": []}, #? NW Jungle (Large Ledge) Exit Bottom -> NW Jungle (Large Ledge) Exit Right
     {"from": {"map": "JAN_09", "id": 1}, "to": {"map": "JAN_09", "id": 0}, "reqs": []}, #? NW Jungle (Large Ledge) Exit Right -> NW Jungle (Large Ledge) Exit Bottom
-    {"from": {"map": "JAN_09", "id": 1}, "to": {"map": "JAN_09", "id": 2}, "reqs": [require(partner="Sushie")]}, #? NW Jungle (Large Ledge) Exit Right -> NW Jungle (Large Ledge) Exit Left
-    {"from": {"map": "JAN_09", "id": 2}, "to": {"map": "JAN_09", "id": 1}, "reqs": [require(partner="Sushie")]}, #? NW Jungle (Large Ledge) Exit Left -> NW Jungle (Large Ledge) Exit Right
-    {"from": {"map": "JAN_09", "id": 1}, "to": {"map": "JAN_09", "id": 3}, "reqs": [require(partner="Sushie")]}, #? NW Jungle (Large Ledge) Exit Right -> NW Jungle (Large Ledge) Pipe On Hill
-    {"from": {"map": "JAN_09", "id": 3}, "to": {"map": "JAN_09", "id": 1}, "reqs": [require(partner="Sushie")]}, #? NW Jungle (Large Ledge) Pipe On Hill -> NW Jungle (Large Ledge) Exit Right
+    {"from": {"map": "JAN_09", "id": 1}, "to": {"map": "JAN_09", "id": 2}, "reqs": [["Sushie"]]}, #? NW Jungle (Large Ledge) Exit Right -> NW Jungle (Large Ledge) Exit Left
+    {"from": {"map": "JAN_09", "id": 2}, "to": {"map": "JAN_09", "id": 1}, "reqs": [["Sushie"]]}, #? NW Jungle (Large Ledge) Exit Left -> NW Jungle (Large Ledge) Exit Right
+    {"from": {"map": "JAN_09", "id": 1}, "to": {"map": "JAN_09", "id": 3}, "reqs": [["Sushie"]]}, #? NW Jungle (Large Ledge) Exit Right -> NW Jungle (Large Ledge) Pipe On Hill
+    {"from": {"map": "JAN_09", "id": 3}, "to": {"map": "JAN_09", "id": 1}, "reqs": [["Sushie"]]}, #? NW Jungle (Large Ledge) Pipe On Hill -> NW Jungle (Large Ledge) Exit Right
 
     {"from": {"map": "JAN_09", "id": 0},             "to": {"map": "JAN_09", "id": "Bush1_Drop1"}, "reqs": []}, #* NW Jungle (Large Ledge) Exit Bottom -> Bush1_Drop1 (Coin)
     {"from": {"map": "JAN_09", "id": "Bush1_Drop1"}, "to": {"map": "JAN_09", "id": 0},             "reqs": []}, #* Bush1_Drop1 (Coin) -> NW Jungle (Large Ledge) Exit Bottom
     {"from": {"map": "JAN_09", "id": 0},             "to": {"map": "JAN_09", "id": "Bush6_Drop1"}, "reqs": []}, #* NW Jungle (Large Ledge) Exit Bottom -> Bush6_Drop1 (Coin)
     {"from": {"map": "JAN_09", "id": "Bush6_Drop1"}, "to": {"map": "JAN_09", "id": 0},             "reqs": []}, #* Bush6_Drop1 (Coin) -> NW Jungle (Large Ledge) Exit Bottom
-    {"from": {"map": "JAN_09", "id": 3},             "to": {"map": "JAN_09", "id": "Tree2_Drop1"}, "reqs": [can_shake_trees]}, #* NW Jungle (Large Ledge) Pipe On Hill -> Tree2_Drop1 (Coin)
+    {"from": {"map": "JAN_09", "id": 3},             "to": {"map": "JAN_09", "id": "Tree2_Drop1"}, "reqs": [["can_shake_trees"]]}, #* NW Jungle (Large Ledge) Pipe On Hill -> Tree2_Drop1 (Coin)
     {"from": {"map": "JAN_09", "id": "Tree2_Drop1"}, "to": {"map": "JAN_09", "id": 3},             "reqs": []}, #* Tree2_Drop1 (Coin) -> NW Jungle (Large Ledge) Pipe On Hill
-    {"from": {"map": "JAN_09", "id": 1},             "to": {"map": "JAN_09", "id": "Tree3_Drop1"}, "reqs": [can_shake_trees]}, #* NW Jungle (Large Ledge) Exit Right -> Tree3_Drop1 (FrightJar)
+    {"from": {"map": "JAN_09", "id": 1},             "to": {"map": "JAN_09", "id": "Tree3_Drop1"}, "reqs": [["can_shake_trees"]]}, #* NW Jungle (Large Ledge) Exit Right -> Tree3_Drop1 (FrightJar)
     {"from": {"map": "JAN_09", "id": "Tree3_Drop1"}, "to": {"map": "JAN_09", "id": 1},             "reqs": []}, #* Tree3_Drop1 (FrightJar) -> NW Jungle (Large Ledge) Exit Right
 
     # JAN_10 Western Dead End
     {"from": {"map": "JAN_10", "id": 0}, "to": {"map": "JAN_09", "id": 2}, "reqs": []}, # Western Dead End Exit Right -> NW Jungle (Large Ledge) Exit Left
 
-    {"from": {"map": "JAN_10", "id": 0},       "to": {"map": "JAN_10", "id": "ItemA"}, "reqs": [require(partner="Sushie")]}, #* Western Dead End Exit Right -> ItemA (StarPiece)
+    {"from": {"map": "JAN_10", "id": 0},       "to": {"map": "JAN_10", "id": "ItemA"}, "reqs": [["Sushie"]]}, #* Western Dead End Exit Right -> ItemA (StarPiece)
     {"from": {"map": "JAN_10", "id": "ItemA"}, "to": {"map": "JAN_10", "id": 0},       "reqs": []}, #* ItemA (StarPiece) -> Western Dead End Exit Right
 
-    {"from": {"map": "JAN_10", "id": 0}, "to": {"map": "JAN_10", "id": 0}, "reqs": [require(flag="RF_YoshiKidsMissing"), require(partner="Sushie"), require(hammer=1)], "pseudoitems": ["RF_SavedYoshiKid_4"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_10", "id": 0}, "to": {"map": "JAN_10", "id": 0}, "reqs": [["RF_YoshiKidsMissing"],["Sushie"],["Hammer"]], "pseudoitems": ["RF_SavedYoshiKid_4"]}, #+ Save Yoshi Kid
 
     # JAN_11 Root Cavern
     {"from": {"map": "JAN_11", "id": 0}, "to": {"map": "JAN_09", "id": 3}, "reqs": []}, # Root Cavern Pipe Left -> NW Jungle (Large Ledge) Pipe On Hill
 
-    {"from": {"map": "JAN_11", "id": 0}, "to": {"map": "JAN_11", "id": 0}, "reqs": [require(flag="RF_YoshiKidsMissing"), require(partner="Watt")], "pseudoitems": ["RF_SavedYoshiKid_5"]}, #+ Save Yoshi Kid
+    {"from": {"map": "JAN_11", "id": 0}, "to": {"map": "JAN_11", "id": 0}, "reqs": [["RF_YoshiKidsMissing"],["Watt"]], "pseudoitems": ["RF_SavedYoshiKid_5"]}, #+ Save Yoshi Kid
 
     # JAN_12 Deep Jungle 1
     {"from": {"map": "JAN_12", "id": 0}, "to": {"map": "JAN_06", "id": 2}, "reqs": []}, # Deep Jungle 1 Exit Bottom Left -> NE Jungle (Raven Statue) Exit Top
@@ -239,7 +237,7 @@ edges_jan = [
 
     {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "Tree1_Drop1"},   "reqs": []}, #* Deep Jungle 1 Exit Bottom Left -> Tree1_Drop1 (Egg)
     {"from": {"map": "JAN_12", "id": "Tree1_Drop1"},   "to": {"map": "JAN_12", "id": 0},               "reqs": []}, #* Tree1_Drop1 (Egg) -> Deep Jungle 1 Exit Bottom Left
-    {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Deep Jungle 1 Exit Bottom Left -> HiddenYBlockA (StoneCap)
+    {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Deep Jungle 1 Exit Bottom Left -> HiddenYBlockA (StoneCap)
     {"from": {"map": "JAN_12", "id": "HiddenYBlockA"}, "to": {"map": "JAN_12", "id": 0},               "reqs": []}, #* HiddenYBlockA (StoneCap) -> Deep Jungle 1 Exit Bottom Left
 
     # JAN_13 Deep Jungle 2 (Block Puzzle)
@@ -249,7 +247,7 @@ edges_jan = [
     {"from": {"map": "JAN_13", "id": 0}, "to": {"map": "JAN_13", "id": 1}, "reqs": []}, #? Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> Deep Jungle 2 (Block Puzzle) Exit Top Right
     {"from": {"map": "JAN_13", "id": 1}, "to": {"map": "JAN_13", "id": 0}, "reqs": []}, #? Deep Jungle 2 (Block Puzzle) Exit Top Right -> Deep Jungle 2 (Block Puzzle) Exit Bottom Left
 
-    {"from": {"map": "JAN_13", "id": 0},               "to": {"map": "JAN_13", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> HiddenYBlockA (VoltShroom)
+    {"from": {"map": "JAN_13", "id": 0},               "to": {"map": "JAN_13", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> HiddenYBlockA (VoltShroom)
     {"from": {"map": "JAN_13", "id": "HiddenYBlockA"}, "to": {"map": "JAN_13", "id": 0},               "reqs": []}, #* HiddenYBlockA (VoltShroom) -> Deep Jungle 2 (Block Puzzle) Exit Bottom Left
 
     # JAN_14 Deep Jungle 3
@@ -271,7 +269,7 @@ edges_jan = [
     {"from": {"map": "JAN_15", "id": 0}, "to": {"map": "JAN_15", "id": 1}, "reqs": []}, #? Deep Jungle 4 (Ambush) Exit Bottom Left -> Deep Jungle 4 (Ambush) Exit Right
     {"from": {"map": "JAN_15", "id": 1}, "to": {"map": "JAN_15", "id": 0}, "reqs": []}, #? Deep Jungle 4 (Ambush) Exit Right -> Deep Jungle 4 (Ambush) Exit Bottom Left
 
-    {"from": {"map": "JAN_15", "id": 0},             "to": {"map": "JAN_15", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Deep Jungle 4 (Ambush) Exit Bottom Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "JAN_15", "id": 0},             "to": {"map": "JAN_15", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Deep Jungle 4 (Ambush) Exit Bottom Left -> HiddenPanel (StarPiece)
     {"from": {"map": "JAN_15", "id": "HiddenPanel"}, "to": {"map": "JAN_15", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Deep Jungle 4 (Ambush) Exit Bottom Left
 
     # JAN_16 Base of Great Tree
@@ -280,8 +278,8 @@ edges_jan = [
     {"from": {"map": "JAN_16", "id": 2}, "to": {"map": "JAN_17", "id": 0}, "reqs": []}, # Base of Great Tree Enter Tree -> Lower Great Tree Interior Exit Bottom
     {"from": {"map": "JAN_16", "id": 4}, "to": {"map": None, "id": None}, "reqs": []},  # Base of Great Tree Fall Off Of Tree
 
-    {"from": {"map": "JAN_16", "id": 0}, "to": {"map": "JAN_16", "id": 1}, "reqs": [require(flag="MF_Ch5_TalkedToRafael")], "pseudoitems": ["MF_Ch5_RafaelMovedRoot"]}, #? Base of Great Tree Exit Left -> Base of Great Tree Exit Right
-    {"from": {"map": "JAN_16", "id": 1}, "to": {"map": "JAN_16", "id": 0}, "reqs": [require(flag="MF_Ch5_TalkedToRafael")]}, #? Base of Great Tree Exit Right -> Base of Great Tree Exit Left
+    {"from": {"map": "JAN_16", "id": 0}, "to": {"map": "JAN_16", "id": 1}, "reqs": [["MF_Ch5_TalkedToRafael"]], "pseudoitems": ["MF_Ch5_RafaelMovedRoot"]}, #? Base of Great Tree Exit Left -> Base of Great Tree Exit Right
+    {"from": {"map": "JAN_16", "id": 1}, "to": {"map": "JAN_16", "id": 0}, "reqs": [["MF_Ch5_TalkedToRafael"]]}, #? Base of Great Tree Exit Right -> Base of Great Tree Exit Left
     {"from": {"map": "JAN_16", "id": 0}, "to": {"map": "JAN_16", "id": 2}, "reqs": []}, #? Base of Great Tree Exit Left -> Base of Great Tree Enter Tree
     {"from": {"map": "JAN_16", "id": 2}, "to": {"map": "JAN_16", "id": 0}, "reqs": []}, #? Base of Great Tree Enter Tree -> Base of Great Tree Exit Left
     {"from": {"map": "JAN_16", "id": 4}, "to": {"map": "JAN_16", "id": 0}, "reqs": []}, #? Base of Great Tree Fall Off Of Tree -> Base of Great Tree Exit Left
@@ -315,17 +313,17 @@ edges_jan = [
     {"from": {"map": "JAN_22", "id": 1}, "to": {"map": "JAN_16", "id": 1}, "reqs": []}, # Path to the Volcano Exit Top -> Base of Great Tree Exit Right
     {"from": {"map": "JAN_22", "id": 2}, "to": {"map": "KZN_01", "id": 0}, "reqs": []}, # Path to the Volcano Exit Right -> Volcano Entrance Exit West (Volcano Entrance)
 
-    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 1}, "reqs": [require(flag="MF_Ch5_RafaelMovedRoot")]}, #? Path to the Volcano Exit Left -> Path to the Volcano Exit Top
+    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 1}, "reqs": [["MF_Ch5_RafaelMovedRoot"]]}, #? Path to the Volcano Exit Left -> Path to the Volcano Exit Top
     {"from": {"map": "JAN_22", "id": 1}, "to": {"map": "JAN_22", "id": 0}, "reqs": []}, #? Path to the Volcano Exit Top -> Path to the Volcano Exit Left
-    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 2}, "reqs": [require(flag="MF_Ch5_ZiplineBuilt")]}, #? Path to the Volcano Exit Left -> Path to the Volcano Exit Right
-    {"from": {"map": "JAN_22", "id": 2}, "to": {"map": "JAN_22", "id": 0}, "reqs": [require(flag="MF_Ch5_ZiplineBuilt")]}, #? Path to the Volcano Exit Right -> Path to the Volcano Exit Left
+    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 2}, "reqs": [["MF_Ch5_ZiplineBuilt"]]}, #? Path to the Volcano Exit Left -> Path to the Volcano Exit Right
+    {"from": {"map": "JAN_22", "id": 2}, "to": {"map": "JAN_22", "id": 0}, "reqs": [["MF_Ch5_ZiplineBuilt"]]}, #? Path to the Volcano Exit Right -> Path to the Volcano Exit Left
 
-    {"from": {"map": "JAN_22", "id": 0},       "to": {"map": "JAN_22", "id": "GiftA"}, "reqs": [require(flag="MF_Ch5_RafaelMovedRoot")], "pseudoitems": ["MF_Ch5_ZiplineBuilt"]}, #* Path to the Volcano Exit Left -> GiftA (UltraStone)
+    {"from": {"map": "JAN_22", "id": 0},       "to": {"map": "JAN_22", "id": "GiftA"}, "reqs": [["MF_Ch5_RafaelMovedRoot"]], "pseudoitems": ["MF_Ch5_ZiplineBuilt"]}, #* Path to the Volcano Exit Left -> GiftA (UltraStone)
     {"from": {"map": "JAN_22", "id": "GiftA"}, "to": {"map": "JAN_22", "id": 0},       "reqs": []}, #* GiftA (UltraStone) -> Path to the Volcano Exit Left
     {"from": {"map": "JAN_22", "id": 0},       "to": {"map": "JAN_22", "id": "ItemA"}, "reqs": []}, #* Path to the Volcano Exit Left -> ItemA (JamminJelly)
     {"from": {"map": "JAN_22", "id": "ItemA"}, "to": {"map": "JAN_22", "id": 0},       "reqs": []}, #* ItemA (JamminJelly) -> Path to the Volcano Exit Left
 
-    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 0}, "reqs": [require(flag="MF_Ch5_FoundEscapeRoute")], "pseudoitems": ["STARSPIRIT_5", "MF_Ch5_RescuedStarSpirit"]}, #+ Get Star Spirit after escaping Volcano
+    {"from": {"map": "JAN_22", "id": 0}, "to": {"map": "JAN_22", "id": 0}, "reqs": [["MF_Ch5_FoundEscapeRoute"]], "pseudoitems": ["STARSPIRIT_5", "MF_Ch5_RescuedStarSpirit"]}, #+ Get Star Spirit after escaping Volcano
 
     # JAN_23 Great Treetop Roost
     {"from": {"map": "JAN_23", "id": 0}, "to": {"map": "JAN_19", "id": 1}, "reqs": []}, # Great Treetop Roost Exit Left -> Upper Great Tree Interior Exit Top

--- a/maps/graph_edges/edges_jan.py
+++ b/maps/graph_edges/edges_jan.py
@@ -32,9 +32,9 @@ edges_jan = [
     {"from": {"map": "JAN_01", "id": "ItemB"},         "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* ItemB (Coin) -> Beach Exit Left
     {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "ItemC"},         "reqs": []}, #* Beach Exit Left -> ItemC (Coin)
     {"from": {"map": "JAN_01", "id": "ItemC"},         "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* ItemC (Coin) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Beach Exit Left -> HiddenYBlockA (RepelGel)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Beach Exit Left -> HiddenYBlockA (RepelGel)
     {"from": {"map": "JAN_01", "id": "HiddenYBlockA"}, "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* HiddenYBlockA (RepelGel) -> Beach Exit Left
-    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockB"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Beach Exit Left -> HiddenYBlockB (Mystery)
+    {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* Beach Exit Left -> HiddenYBlockB (Mystery)
     {"from": {"map": "JAN_01", "id": "HiddenYBlockB"}, "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* HiddenYBlockB (Mystery) -> Beach Exit Left
     {"from": {"map": "JAN_01", "id": 0},               "to": {"map": "JAN_01", "id": "Tree2_Drop1"},   "reqs": [["can_shake_trees"]]}, #* Beach Exit Left -> Tree2_Drop1 (Coconut)
     {"from": {"map": "JAN_01", "id": "Tree2_Drop1"},   "to": {"map": "JAN_01", "id": 0},               "reqs": []}, #* Tree2_Drop1 (Coconut) -> Beach Exit Left
@@ -188,7 +188,7 @@ edges_jan = [
     {"from": {"map": "JAN_08", "id": "ItemB"},         "to": {"map": "JAN_08", "id": 0},               "reqs": []}, #* ItemB (Coin) -> SW Jungle (Super Block) Exit Bottom Left
     {"from": {"map": "JAN_08", "id": 0},               "to": {"map": "JAN_08", "id": "ItemC"},         "reqs": [["Sushie"]]}, #* SW Jungle (Super Block) Exit Bottom Left -> ItemC (Coin)
     {"from": {"map": "JAN_08", "id": "ItemC"},         "to": {"map": "JAN_08", "id": 0},               "reqs": []}, #* ItemC (Coin) -> SW Jungle (Super Block) Exit Bottom Left
-    {"from": {"map": "JAN_08", "id": 2},               "to": {"map": "JAN_08", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* SW Jungle (Super Block) Exit Top -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "JAN_08", "id": 2},               "to": {"map": "JAN_08", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* SW Jungle (Super Block) Exit Top -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "JAN_08", "id": "HiddenYBlockA"}, "to": {"map": "JAN_08", "id": 2},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> SW Jungle (Super Block) Exit Top
 
     {"from": {"map": "JAN_08", "id": 0}, "to": {"map": "JAN_08", "id": 0}, "reqs": [["RF_YoshiKidsMissing"]], "pseudoitems": ["RF_SavedYoshiKid_3"]}, #+ Save Yoshi Kid
@@ -237,7 +237,7 @@ edges_jan = [
 
     {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "Tree1_Drop1"},   "reqs": []}, #* Deep Jungle 1 Exit Bottom Left -> Tree1_Drop1 (Egg)
     {"from": {"map": "JAN_12", "id": "Tree1_Drop1"},   "to": {"map": "JAN_12", "id": 0},               "reqs": []}, #* Tree1_Drop1 (Egg) -> Deep Jungle 1 Exit Bottom Left
-    {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Deep Jungle 1 Exit Bottom Left -> HiddenYBlockA (StoneCap)
+    {"from": {"map": "JAN_12", "id": 0},               "to": {"map": "JAN_12", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Deep Jungle 1 Exit Bottom Left -> HiddenYBlockA (StoneCap)
     {"from": {"map": "JAN_12", "id": "HiddenYBlockA"}, "to": {"map": "JAN_12", "id": 0},               "reqs": []}, #* HiddenYBlockA (StoneCap) -> Deep Jungle 1 Exit Bottom Left
 
     # JAN_13 Deep Jungle 2 (Block Puzzle)
@@ -247,7 +247,7 @@ edges_jan = [
     {"from": {"map": "JAN_13", "id": 0}, "to": {"map": "JAN_13", "id": 1}, "reqs": []}, #? Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> Deep Jungle 2 (Block Puzzle) Exit Top Right
     {"from": {"map": "JAN_13", "id": 1}, "to": {"map": "JAN_13", "id": 0}, "reqs": []}, #? Deep Jungle 2 (Block Puzzle) Exit Top Right -> Deep Jungle 2 (Block Puzzle) Exit Bottom Left
 
-    {"from": {"map": "JAN_13", "id": 0},               "to": {"map": "JAN_13", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> HiddenYBlockA (VoltShroom)
+    {"from": {"map": "JAN_13", "id": 0},               "to": {"map": "JAN_13", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Deep Jungle 2 (Block Puzzle) Exit Bottom Left -> HiddenYBlockA (VoltShroom)
     {"from": {"map": "JAN_13", "id": "HiddenYBlockA"}, "to": {"map": "JAN_13", "id": 0},               "reqs": []}, #* HiddenYBlockA (VoltShroom) -> Deep Jungle 2 (Block Puzzle) Exit Bottom Left
 
     # JAN_14 Deep Jungle 3

--- a/maps/graph_edges/edges_kgr.py
+++ b/maps/graph_edges/edges_kgr.py
@@ -1,6 +1,4 @@
 """This file represents all edges of the world graph that have origin-nodes in the KGR (Inside the Whale) area."""
-from rando_modules.simulate import *
-
 edges_kgr = [
     # KGR_01 Whale Mouth
     {"from": {"map": "KGR_01", "id": 0}, "to": {"map": "MAC_05", "id": 3}, "reqs": []}, # Whale Mouth Exit West -> Port District Enter Whale
@@ -11,5 +9,5 @@ edges_kgr = [
     
     # KGR_02 Whale Stomach
     {"from": {"map": "KGR_02", "id": 0}, "to": {"map": "KGR_01", "id": 1}, "reqs": []}, # Whale Stomach Exit West -> Whale Mouth Exit East
-    {"from": {"map": "KGR_02", "id": 0}, "to": {"map": "KGR_02", "id": 0}, "reqs": [require(partner="Watt")], "pseudoitems":["RF_CanRideWhale"]}, #+ Defeat Fuzzipede
+    {"from": {"map": "KGR_02", "id": 0}, "to": {"map": "KGR_02", "id": 0}, "reqs": [["Watt"]], "pseudoitems":["RF_CanRideWhale"]}, #+ Defeat Fuzzipede
 ]

--- a/maps/graph_edges/edges_kkj.py
+++ b/maps/graph_edges/edges_kkj.py
@@ -1,6 +1,4 @@
 """This file represents all edges of the world graph that have origin-nodes in the KKJ (Peach's Castle) area."""
-from rando_modules.simulate import require
-
 edges_kkj = [
     # KKJ_10 Entry Hall (1F)
     {"from": {"map": "KKJ_10", "id": 0}, "to": {"map": "OSR_02", "id": 1}, "reqs": []}, # Entry Hall (1F) Door Bottom -> Hijacked Castle Entrance Door North
@@ -117,7 +115,7 @@ edges_kkj = [
     # KKJ_25 Final Boss Arena (6F)
     {"from": {"map": "KKJ_25", "id": 0}, "to": {"map": "KKJ_24", "id": 1}, "reqs": []}, # Final Boss Arena (6F) Door Left -> Tower Staircase (5F) Door Top
 
-    {"from": {"map": "KKJ_25", "id": 0}, "to": {"map": "KKJ_24", "id": 1}, "reqs": [require(flag="RF_HasStarbeam")], "pseudoitems": ["YOUWIN"]}, #+ Beat Bowser
+    {"from": {"map": "KKJ_25", "id": 0}, "to": {"map": "KKJ_24", "id": 1}, "reqs": [["RF_HasStarbeam"]], "pseudoitems": ["YOUWIN"]}, #+ Beat Bowser
 
     # KKJ_26 Balcony (2F)
     {"from": {"map": "KKJ_26", "id": 0}, "to": {"map": "KKJ_14", "id": 1}, "reqs": []}, # Balcony (2F) Door Left -> Peach's Room (2F) Door Right

--- a/maps/graph_edges/edges_kmr.py
+++ b/maps/graph_edges/edges_kmr.py
@@ -1,11 +1,9 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the KMR (Goomba Region) area."""
 edges_kmr  = [
     # KMR_00 Forest Clearing
     {"from": {"map": "KMR_00", "id": 0},             "to": {"map": "KMR_02", "id": 1},             "reqs": []}, # Forest Clearing Exit East -> Goomba Village Exit Left
 
-    {"from": {"map": "KMR_00", "id": 0},             "to": {"map": "KMR_00", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Forest Clearing Exit East -> HiddenPanel
+    {"from": {"map": "KMR_00", "id": 0},             "to": {"map": "KMR_00", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Forest Clearing Exit East -> HiddenPanel
     {"from": {"map": "KMR_00", "id": "HiddenPanel"}, "to": {"map": "KMR_00", "id": 0},             "reqs": []}, #* HiddenPanel -> Forest Clearing Exit East
 
     # KMR_02 Goomba Village
@@ -14,22 +12,22 @@ edges_kmr  = [
     {"from": {"map": "KMR_02", "id": 2             },  "to": {"map": "KMR_05", "id": 1             },  "reqs": []}, # Goomba Village Exit Top Left -> Behind the Village Exit Right
     {"from": {"map": "KMR_02", "id": 3             },  "to": {"map": "TIK_01", "id": 2             },  "reqs": []}, # Goomba Village Blue Warp Pipe -> Warp Zone 1 (B1) Blue Pipe (Right)
 
-    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": 0             },  "reqs": [require(hammer=1)]}, #? Goomba Village Exit Left -> Goomba Village Exit Right
-    {"from": {"map": "KMR_02", "id": 0             },  "to": {"map": "KMR_02", "id": 1             },  "reqs": [require(hammer=1)]}, #? Goomba Village Exit Right -> Goomba Village Exit Left
+    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": 0             },  "reqs": [["Hammer"]]}, #? Goomba Village Exit Left -> Goomba Village Exit Right
+    {"from": {"map": "KMR_02", "id": 0             },  "to": {"map": "KMR_02", "id": 1             },  "reqs": [["Hammer"]]}, #? Goomba Village Exit Right -> Goomba Village Exit Left
     {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": 2             },  "reqs": []}, #? Goomba Village Exit Left -> Goomba Village Exit Top Left
     {"from": {"map": "KMR_02", "id": 2             },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #? Goomba Village Exit Top Left -> Goomba Village Exit Left
-    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": 3             },  "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Goomba Village Exit Left -> Goomba Village Blue Warp Pipe
+    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": 3             },  "reqs": [["GF_TIK01_WarpPipes"]]}, #? Goomba Village Exit Left -> Goomba Village Blue Warp Pipe
     {"from": {"map": "KMR_02", "id": 3             },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #? Goomba Village Blue Warp Pipe -> Goomba Village Exit Left
 
     {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "ItemA"       },  "reqs": []}, #* Goomba Village Exit Left -> ItemA (ShootingStar)
     {"from": {"map": "KMR_02", "id": "ItemA"       },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* ItemA (ShootingStar) -> Goomba Village Exit Left
-    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "GiftA"       },  "reqs": [require(favor="FAVOR_2_01_active")]}, #* Goomba Village Exit Left -> GiftA (KootTheTape)
+    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "GiftA"       },  "reqs": [["FAVOR_2_01_active"]]}, #* Goomba Village Exit Left -> GiftA (KootTheTape)
     {"from": {"map": "KMR_02", "id": "GiftA"       },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* GiftA (KootTheTape) -> Goomba Village Exit Left
     {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "GiftB"       },  "reqs": []}, #* Goomba Village Exit Left -> GiftB (PowerJump)
     {"from": {"map": "KMR_02", "id": "GiftB"       },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* GiftB (PowerJump) -> Goomba Village Exit Left
-    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "GiftC"       },  "reqs": [require(item="Dolly")]}, #* Goomba Village Exit Left -> GiftC (StarPiece)
+    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "GiftC"       },  "reqs": [["Dolly"]]}, #* Goomba Village Exit Left -> GiftC (StarPiece)
     {"from": {"map": "KMR_02", "id": "GiftC"       },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* GiftC (StarPiece) -> Goomba Village Exit Left
-    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "Tree1_Drop1A"},  "reqs": [can_shake_trees]}, #* Goomba Village Exit Left -> Tree1_Drop1A (Goomnut)
+    {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "Tree1_Drop1A"},  "reqs": [["can_shake_trees"]]}, #* Goomba Village Exit Left -> Tree1_Drop1A (Goomnut)
     {"from": {"map": "KMR_02", "id": "Tree1_Drop1A"},  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* Tree1_Drop1A (Goomnut) -> Goomba Village Exit Left
     {"from": {"map": "KMR_02", "id": 1             },  "to": {"map": "KMR_02", "id": "Partner"     },  "reqs": []}, #* Goomba Village Exit Left -> Partner (Goombario)
     {"from": {"map": "KMR_02", "id": "Partner"     },  "to": {"map": "KMR_02", "id": 1             },  "reqs": []}, #* Partner (Goombario) -> Goomba Village Exit Left
@@ -52,7 +50,7 @@ edges_kmr  = [
     
     {"from": {"map": "KMR_05", "id": 1      },         "to": {"map": "KMR_05", "id": "ItemA"},         "reqs": []}, #* Behind the Village Exit Right -> ItemA (StarPiece)
     {"from": {"map": "KMR_05", "id": "ItemA"},         "to": {"map": "KMR_05", "id": 1      },         "reqs": []}, #* ItemA (StarPiece) -> Behind the Village Exit Right
-    {"from": {"map": "KMR_05", "id": 1      },         "to": {"map": "KMR_05", "id": "Tree1_Drop1A"},  "reqs": [can_shake_trees]}, #* Behind the Village Exit Right -> Tree1_Drop1A (Coin)
+    {"from": {"map": "KMR_05", "id": 1      },         "to": {"map": "KMR_05", "id": "Tree1_Drop1A"},  "reqs": [["can_shake_trees"]]}, #* Behind the Village Exit Right -> Tree1_Drop1A (Coin)
     {"from": {"map": "KMR_05", "id": "Tree1_Drop1A"},  "to": {"map": "KMR_05", "id": 1      },         "reqs": []}, #* Tree1_Drop1A (Coin) -> Behind the Village Exit Right
 
     # KMR_03 Bottom of the Cliff
@@ -62,13 +60,13 @@ edges_kmr  = [
     {"from": {"map": "KMR_03", "id": 0}, "to": {"map": "KMR_03", "id": 1}, "reqs": []}, #? Bottom of the Cliff Exit Left -> Bottom of the Cliff Exit Right
     {"from": {"map": "KMR_03", "id": 1}, "to": {"map": "KMR_03", "id": 0}, "reqs": []}, #? Bottom of the Cliff Exit Right -> Bottom of the Cliff Exit Left
     
-    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "YBlockA"},       "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Bottom of the Cliff Exit Left -> YBlockA (Coin)
+    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "YBlockA"},       "reqs": [["can_hit_grounded_blocks"]]}, #* Bottom of the Cliff Exit Left -> YBlockA (Coin)
     {"from": {"map": "KMR_03", "id": "YBlockA"},       "to": {"map": "KMR_03", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> Bottom of the Cliff Exit Left
-    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "Tree1_Drop1A"},  "reqs": [can_shake_trees]}, #* Bottom of the Cliff Exit Left -> Tree1_Drop1A (Mushroom)
+    {"from": {"map": "KMR_03", "id": 0},               "to": {"map": "KMR_03", "id": "Tree1_Drop1A"},  "reqs": [["can_shake_trees"]]}, #* Bottom of the Cliff Exit Left -> Tree1_Drop1A (Mushroom)
     {"from": {"map": "KMR_03", "id": "Tree1_Drop1A"},  "to": {"map": "KMR_03", "id": 0},               "reqs": []}, #* Tree1_Drop1A (Mushroom) -> Bottom of the Cliff Exit Left
-    {"from": {"map": "KMR_03", "id": 1},               "to": {"map": "KMR_03", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* Bottom of the Cliff Exit Right -> HiddenPanel (StarPiece)
+    {"from": {"map": "KMR_03", "id": 1},               "to": {"map": "KMR_03", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* Bottom of the Cliff Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "KMR_03", "id": "HiddenPanel"},   "to": {"map": "KMR_03", "id": 1},               "reqs": []}, #* HiddenPanel (StarPiece) -> Bottom of the Cliff Exit Right
-    {"from": {"map": "KMR_03", "id": 1},               "to": {"map": "KMR_03", "id": "HiddenYBlockA"}, "reqs": [require(hammer=2), require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Bottom of the Cliff Exit Right -> HiddenYBlockA (RepelGel)
+    {"from": {"map": "KMR_03", "id": 1},               "to": {"map": "KMR_03", "id": "HiddenYBlockA"}, "reqs": [["SuperHammer"],["can_see_hidden_blocks"]]}, #* Bottom of the Cliff Exit Right -> HiddenYBlockA (RepelGel)
     {"from": {"map": "KMR_03", "id": "HiddenYBlockA"}, "to": {"map": "KMR_03", "id": 1},               "reqs": []}, #* HiddenYBlockA (RepelGel) -> Bottom of the Cliff Exit Right
     {"from": {"map": "KMR_03", "id": 1},               "to": {"map": "KMR_03", "id": "ItemA"},         "reqs": []}, #* Bottom of the Cliff Exit Right -> ItemA (Coin)
     {"from": {"map": "KMR_03", "id": "ItemA"},         "to": {"map": "KMR_03", "id": 1},               "reqs": []}, #* ItemA (Coin) -> Bottom of the Cliff Exit Right
@@ -84,7 +82,7 @@ edges_kmr  = [
     # KMR_04 Jr. Troopa's Playground
     {"from": {"map": "KMR_04", "id": 0}, "to": {"map": "KMR_03", "id": 0}, "reqs": []}, # Jr. Troopa's Playground Exit Right -> Bottom of the Cliff Exit Left
 
-    {"from": {"map": "KMR_04", "id": 0},              "to": {"map": "KMR_04", "id": "Tree3_Drop1A"}, "reqs": [can_shake_trees]}, #* Jr. Troopa's Playground Exit Right -> Tree3_Drop1A (Dolly)
+    {"from": {"map": "KMR_04", "id": 0},              "to": {"map": "KMR_04", "id": "Tree3_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Jr. Troopa's Playground Exit Right -> Tree3_Drop1A (Dolly)
     {"from": {"map": "KMR_04", "id": "Tree3_Drop1A"}, "to": {"map": "KMR_04", "id": 0},              "reqs": []}, #* Tree3_Drop1A (Dolly) -> Jr. Troopa's Playground Exit Right
 
     # KMR_09 Goomba Road 1
@@ -131,14 +129,14 @@ edges_kmr  = [
     {"from": {"map": "KMR_11", "id": 0}, "to": {"map": "KMR_12", "id": 1}, "reqs": []}, # Goomba King's Castle Exit Left -> Goomba Road 4 Exit Right
     {"from": {"map": "KMR_11", "id": 1}, "to": {"map": "KMR_10", "id": 0}, "reqs": []}, # Goomba King's Castle Exit Right -> Toad Town Entrance Exit Left
     
-    {"from": {"map": "KMR_11", "id": 0}, "to": {"map": "KMR_11", "id": 1}, "reqs": [require(flag="RF_BeatGoombaBros")], "pseudoitems": ["RF_BeatGoombaKing"]}, #? Goomba King's Castle Exit Left -> Goomba King's Castle Exit Right
-    {"from": {"map": "KMR_11", "id": 1}, "to": {"map": "KMR_11", "id": 0}, "reqs": [require(flag="RF_BeatGoombaKing")]}, #? Goomba King's Castle Exit Right -> Goomba King's Castle Exit Left
+    {"from": {"map": "KMR_11", "id": 0}, "to": {"map": "KMR_11", "id": 1}, "reqs": [["RF_BeatGoombaBros"]], "pseudoitems": ["RF_BeatGoombaKing"]}, #? Goomba King's Castle Exit Left -> Goomba King's Castle Exit Right
+    {"from": {"map": "KMR_11", "id": 1}, "to": {"map": "KMR_11", "id": 0}, "reqs": [["RF_BeatGoombaKing"]]}, #? Goomba King's Castle Exit Right -> Goomba King's Castle Exit Left
     
-    {"from": {"map": "KMR_11", "id": 0},              "to": {"map": "KMR_11", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* Goomba King's Castle Exit Left -> Tree1_Drop1A (StarPiece)
+    {"from": {"map": "KMR_11", "id": 0},              "to": {"map": "KMR_11", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Goomba King's Castle Exit Left -> Tree1_Drop1A (StarPiece)
     {"from": {"map": "KMR_11", "id": "Tree1_Drop1A"}, "to": {"map": "KMR_11", "id": 0},              "reqs": []}, #* Tree1_Drop1A (StarPiece) -> Goomba King's Castle Exit Left
-    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "HiddenPanel"},  "reqs": [can_flip_panels]}, #* Goomba King's Castle Exit Right -> HiddenPanel (StarPiece)
+    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "HiddenPanel"},  "reqs": [["can_flip_panels"]]}, #* Goomba King's Castle Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "KMR_11", "id": "HiddenPanel"},  "to": {"map": "KMR_11", "id": 1},              "reqs": []}, #* HiddenPanel (StarPiece) -> Goomba King's Castle Exit Right
-    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "YBlockA"},      "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* Goomba King's Castle Exit Right -> YBlockA (SuperShroom)
+    {"from": {"map": "KMR_11", "id": 1},              "to": {"map": "KMR_11", "id": "YBlockA"},      "reqs": [["can_hit_grounded_blocks"]]}, #* Goomba King's Castle Exit Right -> YBlockA (SuperShroom)
     {"from": {"map": "KMR_11", "id": "YBlockA"},      "to": {"map": "KMR_11", "id": 1},              "reqs": []}, #* YBlockA (SuperShroom) -> Goomba King's Castle Exit Right
 
     # KMR_10 Toad Town Entrance
@@ -150,12 +148,12 @@ edges_kmr  = [
     
     {"from": {"map": "KMR_10", "id": 1},         "to": {"map": "KMR_10", "id": "YBlockA"}, "reqs": []}, #* Toad Town Entrance Exit Right -> YBlockA (SleepySheep)
     {"from": {"map": "KMR_10", "id": "YBlockA"}, "to": {"map": "KMR_10", "id": 1},         "reqs": []}, #* YBlockA (SleepySheep) -> Toad Town Entrance Exit Right
-    {"from": {"map": "KMR_10", "id": 1},         "to": {"map": "KMR_10", "id": "ChestA"},  "reqs": [can_shake_trees]}, #* Toad Town Entrance Exit Right -> ChestA (HammerThrow)
+    {"from": {"map": "KMR_10", "id": 1},         "to": {"map": "KMR_10", "id": "ChestA"},  "reqs": [["can_shake_trees"]]}, #* Toad Town Entrance Exit Right -> ChestA (HammerThrow)
     {"from": {"map": "KMR_10", "id": "ChestA"},  "to": {"map": "KMR_10", "id": 1},         "reqs": []}, #* ChestA (HammerThrow) -> Toad Town Entrance Exit Right
 
     # KMR_20 Mario's House
     {"from": {"map": "KMR_20", "id": 4}, "to": {"map": "MAC_00", "id": 4}, "reqs": []}, # Mario's House Green Pipe -> Gate District Top Green Pipe
 
-    {"from": {"map": "KMR_20", "id": 4},       "to": {"map": "KMR_20", "id": "GiftA"}, "reqs": [require(favor="FAVOR_2_03_active")]}, #* Mario's House Green Pipe -> GiftA (KootLuigiAutograph)
+    {"from": {"map": "KMR_20", "id": 4},       "to": {"map": "KMR_20", "id": "GiftA"}, "reqs": [["FAVOR_2_03_active"]]}, #* Mario's House Green Pipe -> GiftA (KootLuigiAutograph)
     {"from": {"map": "KMR_20", "id": "GiftA"}, "to": {"map": "KMR_20", "id": 4},       "reqs": []}, #* GiftA (KootLuigiAutograph) -> Mario's House Green Pipe
 ]

--- a/maps/graph_edges/edges_kpa.py
+++ b/maps/graph_edges/edges_kpa.py
@@ -100,8 +100,8 @@ edges_kpa = [
     {"from": {"map": "KPA_14",  "id": 1}, "to": {"map": "KPA_01",  "id": 0}, "reqs": []}, # Lava Channel 3 Door Right -> Dark Cave 1 Door Bottom Left
     {"from": {"map": "KPA_14",  "id": 2}, "to": {"map": "KPA_16",  "id": 0}, "reqs": []}, # Lava Channel 3 Lava Door Center -> Lava Control Room Lava Door Left
     
-    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 1}, "reqs": [[{"BowserCastleKey": 2}]]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Door Right
-    #! require(flag="GF_KPA16_ShutOffLava") ^ 
+    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 1}, "reqs": [[{"BowserCastleKey": 2}],["GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Door Right
+
     {"from": {"map": "KPA_14",  "id": 1}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Door Right -> Lava Channel 3 Door Left
     {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 2}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"],["Bow","GF_KPA16_ShutOffLava"],["Parakarry","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Lava Door Center
     {"from": {"map": "KPA_14",  "id": 2}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Lava Door Center -> Lava Channel 3 Door Left
@@ -205,7 +205,7 @@ edges_kpa = [
     {"from": {"map": "KPA_52",  "id": 1}, "to": {"map": "KPA_40",  "id": 0}, "reqs": []}, # Split Level Hall Door Bottom Right -> Maze Guide Room Door Left
     {"from": {"map": "KPA_52",  "id": 2}, "to": {"map": "KPA_08",  "id": 0}, "reqs": []}, # Split Level Hall Door Top Right -> Castle Key Timing Puzzle Door Left
     
-    {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 1}, "reqs": [[{"BowserCastleKey": 3}]]}, #? Split Level Hall Door Left -> Split Level Hall Door Bottom Right
+    {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 1}, "reqs": [[{"BowserCastleKey": 5}]]}, #? Split Level Hall Door Left -> Split Level Hall Door Bottom Right
     {"from": {"map": "KPA_52",  "id": 1}, "to": {"map": "KPA_52",  "id": 0}, "reqs": []}, #? Split Level Hall Door Bottom Right -> Split Level Hall Door Left
     {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 2}, "reqs": []}, #? Split Level Hall Door Left -> Split Level Hall Door Top Right
     {"from": {"map": "KPA_52",  "id": 2}, "to": {"map": "KPA_52",  "id": 0}, "reqs": []}, #? Split Level Hall Door Top Right -> Split Level Hall Door Left
@@ -367,7 +367,7 @@ edges_kpa = [
     
     {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "YBlockA"},       "reqs": []}, #* Room with Hidden Door 1 Door Left -> YBlockA (SuperShroom)
     {"from": {"map": "KPA_111", "id": "YBlockA"},       "to": {"map": "KPA_111", "id": 0},               "reqs": []}, #* YBlockA (SuperShroom) -> Room with Hidden Door 1 Door Left
-    {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Room with Hidden Door 1 Door Left -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Room with Hidden Door 1 Door Left -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "KPA_111", "id": "HiddenYBlockA"}, "to": {"map": "KPA_111", "id": 0},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> Room with Hidden Door 1 Door Left
 
     # KPA_112 Hidden Passage 1
@@ -463,7 +463,7 @@ edges_kpa = [
     {"from": {"map": "KPA_134", "id": 2}, "to": {"map": "KPA_133", "id": 2}, "reqs": []}, # Right Water Puzzle Door Bottom Left Upper Half -> Left Water Puzzle Door Bottom Right Upper Half
     {"from": {"map": "KPA_134", "id": 3}, "to": {"map": "KPA_133", "id": 3}, "reqs": []}, # Right Water Puzzle Bombable Wall -> Left Water Puzzle Door Bombable Wall
     
-    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 1}, "reqs": [[{"BowserCastleKey": 5}]]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Right
+    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 1}, "reqs": [[{"BowserCastleKey": 3}]]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Right
     {"from": {"map": "KPA_134", "id": 1}, "to": {"map": "KPA_134", "id": 0}, "reqs": []}, #? Right Water Puzzle Door Bottom Right -> Right Water Puzzle Door Bottom Left
     {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 2}, "reqs": [["Sushie"]]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Left Upper Half
     {"from": {"map": "KPA_134", "id": 2}, "to": {"map": "KPA_134", "id": 0}, "reqs": [["Sushie"]]}, #? Right Water Puzzle Door Bottom Left Upper Half -> Right Water Puzzle Door Bottom Left

--- a/maps/graph_edges/edges_kpa.py
+++ b/maps/graph_edges/edges_kpa.py
@@ -6,17 +6,17 @@ edges_kpa = [
     {"from": {"map": "KPA_01",  "id": 0}, "to": {"map": "KPA_14",  "id": 1}, "reqs": []}, # Dark Cave 1 Door Bottom Left -> Lava Channel 3 Door Right
     {"from": {"map": "KPA_01",  "id": 1}, "to": {"map": "KPA_03",  "id": 0}, "reqs": []}, # Dark Cave 1 Exit Top Left -> Dark Cave 2 Exit Right
     
-    {"from": {"map": "KPA_01",  "id": 0}, "to": {"map": "KPA_01",  "id": 1}, "reqs": [require(partner="Parakarry")]}, #? Dark Cave 1 Door Bottom Left -> Dark Cave 1 Exit Top Left
+    {"from": {"map": "KPA_01",  "id": 0}, "to": {"map": "KPA_01",  "id": 1}, "reqs": [["Parakarry"]]}, #? Dark Cave 1 Door Bottom Left -> Dark Cave 1 Exit Top Left
     {"from": {"map": "KPA_01",  "id": 1}, "to": {"map": "KPA_01",  "id": 0}, "reqs": []}, #? Dark Cave 1 Exit Top Left -> Dark Cave 1 Door Bottom Left
     
-    {"from": {"map": "KPA_01",  "id": 1},         "to": {"map": "KPA_01",  "id": "YBlockA"}, "reqs": [require(partner="Parakarry")]}, #* Dark Cave 1 Exit Top Left -> YBlockA (POWBlock)
+    {"from": {"map": "KPA_01",  "id": 1},         "to": {"map": "KPA_01",  "id": "YBlockA"}, "reqs": [["Parakarry"]]}, #* Dark Cave 1 Exit Top Left -> YBlockA (POWBlock)
     {"from": {"map": "KPA_01",  "id": "YBlockA"}, "to": {"map": "KPA_01",  "id": 1},         "reqs": []}, #* YBlockA (POWBlock) -> Dark Cave 1 Exit Top Left
     
     # KPA_03 Dark Cave 2
     {"from": {"map": "KPA_03",  "id": 0}, "to": {"map": "KPA_01",  "id": 1}, "reqs": []}, # Dark Cave 2 Exit Right -> Dark Cave 1 Exit Top Left
     {"from": {"map": "KPA_03",  "id": 1}, "to": {"map": "KPA_04",  "id": 0}, "reqs": []}, # Dark Cave 2 Door Top Left -> Cave Exit Door Right
     
-    {"from": {"map": "KPA_03",  "id": 0}, "to": {"map": "KPA_03",  "id": 1}, "reqs": [require(partner="Parakarry")]}, #? Dark Cave 2 Exit Right -> Dark Cave 2 Door Top Left
+    {"from": {"map": "KPA_03",  "id": 0}, "to": {"map": "KPA_03",  "id": 1}, "reqs": [["Parakarry"]]}, #? Dark Cave 2 Exit Right -> Dark Cave 2 Door Top Left
     {"from": {"map": "KPA_03",  "id": 1}, "to": {"map": "KPA_03",  "id": 0}, "reqs": []}, #? Dark Cave 2 Door Top Left -> Dark Cave 2 Exit Right
     
     {"from": {"map": "KPA_03",  "id": 0},         "to": {"map": "KPA_03",  "id": "YBlockA"}, "reqs": []}, #* Dark Cave 2 Exit Right -> YBlockA (ShootingStar)
@@ -33,7 +33,7 @@ edges_kpa = [
     {"from": {"map": "KPA_08",  "id": 0}, "to": {"map": "KPA_52",  "id": 2}, "reqs": []}, # Castle Key Timing Puzzle Door Left -> Split Level Hall Door Top Right
     {"from": {"map": "KPA_08",  "id": 1}, "to": {"map": "KPA_100", "id": 0}, "reqs": []}, # Castle Key Timing Puzzle Door Right -> Castle Key Room Door Left
     
-    {"from": {"map": "KPA_08",  "id": 0}, "to": {"map": "KPA_08",  "id": 1}, "reqs": [require(partner=["Kooper","Bombette"])]}, #? Castle Key Timing Puzzle Door Left -> Castle Key Timing Puzzle Door Right
+    {"from": {"map": "KPA_08",  "id": 0}, "to": {"map": "KPA_08",  "id": 1}, "reqs": [["Kooper","Bombette"]]}, #? Castle Key Timing Puzzle Door Left -> Castle Key Timing Puzzle Door Right
     {"from": {"map": "KPA_08",  "id": 1}, "to": {"map": "KPA_08",  "id": 0}, "reqs": []}, #? Castle Key Timing Puzzle Door Right -> Castle Key Timing Puzzle Door Left
 
     # KPA_09 Ultra Shroom Timing Puzzle
@@ -41,7 +41,7 @@ edges_kpa = [
     {"from": {"map": "KPA_09",  "id": 1}, "to": {"map": "KPA_33",  "id": 3}, "reqs": []}, # Ultra Shroom Timing Puzzle Door Right -> Upper Grand Hall Door Top Left
     
     {"from": {"map": "KPA_09",  "id": 0}, "to": {"map": "KPA_09",  "id": 1}, "reqs": []}, #? Ultra Shroom Timing Puzzle Door Left -> Ultra Shroom Timing Puzzle Door Right
-    {"from": {"map": "KPA_09",  "id": 1}, "to": {"map": "KPA_09",  "id": 0}, "reqs": [require(partner="Bombette")]}, #? Ultra Shroom Timing Puzzle Door Right -> Ultra Shroom Timing Puzzle Door Left
+    {"from": {"map": "KPA_09",  "id": 1}, "to": {"map": "KPA_09",  "id": 0}, "reqs": [["Bombette"]]}, #? Ultra Shroom Timing Puzzle Door Right -> Ultra Shroom Timing Puzzle Door Left
 
     # KPA_10 Outside Lower Jail (No Lava)
     {"from": {"map": "KPA_10",  "id": 0}, "to": {"map": "KPA_62",  "id": 1}, "reqs": []}, # Outside Lower Jail (No Lava) Door Top Left -> Front Door Exterior Door Right
@@ -52,10 +52,10 @@ edges_kpa = [
     
     {"from": {"map": "KPA_10",  "id": 1}, "to": {"map": "KPA_10",  "id": 2}, "reqs": []}, #? Outside Lower Jail (No Lava) Door Right -> Outside Lower Jail (No Lava) Cracked Wall To Jail
     {"from": {"map": "KPA_10",  "id": 2}, "to": {"map": "KPA_10",  "id": 1}, "reqs": []}, #? Outside Lower Jail (No Lava) Cracked Wall To Jail -> Outside Lower Jail (No Lava) Door Right
-    {"from": {"map": "KPA_10",  "id": 3}, "to": {"map": "KPA_10",  "id": 4}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Outside Lower Jail (No Lava) Lava Door Left -> Outside Lower Jail (No Lava) Lava Door Right
-    {"from": {"map": "KPA_10",  "id": 4}, "to": {"map": "KPA_10",  "id": 3}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Outside Lower Jail (No Lava) Lava Door Right -> Outside Lower Jail (No Lava) Lava Door Left
+    {"from": {"map": "KPA_10",  "id": 3}, "to": {"map": "KPA_10",  "id": 4}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Outside Lower Jail (No Lava) Lava Door Left -> Outside Lower Jail (No Lava) Lava Door Right
+    {"from": {"map": "KPA_10",  "id": 4}, "to": {"map": "KPA_10",  "id": 3}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Outside Lower Jail (No Lava) Lava Door Right -> Outside Lower Jail (No Lava) Lava Door Left
     
-    {"from": {"map": "KPA_10",  "id": 4},         "to": {"map": "KPA_10",  "id": "YBlockA"}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #* Outside Lower Jail (No Lava) Lava Door Right -> YBlockA (LifeShroom)
+    {"from": {"map": "KPA_10",  "id": 4},         "to": {"map": "KPA_10",  "id": "YBlockA"}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #* Outside Lower Jail (No Lava) Lava Door Right -> YBlockA (LifeShroom)
     {"from": {"map": "KPA_10",  "id": "YBlockA"}, "to": {"map": "KPA_10",  "id": 4},         "reqs": []}, #* YBlockA (LifeShroom) -> Outside Lower Jail (No Lava) Lava Door Right
 
     # KPA_11 Outside Lower Jail (Lava)
@@ -67,8 +67,8 @@ edges_kpa = [
     
     {"from": {"map": "KPA_11",  "id": 1}, "to": {"map": "KPA_11",  "id": 2}, "reqs": []}, #? Outside Lower Jail (Lava) Door Right -> Outside Lower Jail (Lava) Cracked Wall To Jail
     {"from": {"map": "KPA_11",  "id": 2}, "to": {"map": "KPA_11",  "id": 1}, "reqs": []}, #? Outside Lower Jail (Lava) Cracked Wall To Jail -> Outside Lower Jail (Lava) Door Right
-    {"from": {"map": "KPA_11",  "id": 3}, "to": {"map": "KPA_11",  "id": 4}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Outside Lower Jail (Lava) Lava Door Left -> Outside Lower Jail (Lava) Lava Door Right
-    {"from": {"map": "KPA_11",  "id": 4}, "to": {"map": "KPA_11",  "id": 3}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Outside Lower Jail (Lava) Lava Door Right -> Outside Lower Jail (Lava) Lava Door Left
+    {"from": {"map": "KPA_11",  "id": 3}, "to": {"map": "KPA_11",  "id": 4}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Outside Lower Jail (Lava) Lava Door Left -> Outside Lower Jail (Lava) Lava Door Right
+    {"from": {"map": "KPA_11",  "id": 4}, "to": {"map": "KPA_11",  "id": 3}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Outside Lower Jail (Lava) Lava Door Right -> Outside Lower Jail (Lava) Lava Door Left
     
     {"from": {"map": "KPA_11",  "id": 0},         "to": {"map": "KPA_11",  "id": "ItemA"},   "reqs": []}, #* Outside Lower Jail (Lava) Door Top Left -> ItemA (BowserCastleKey)
     {"from": {"map": "KPA_11",  "id": "ItemA"},   "to": {"map": "KPA_11",  "id": 0},         "reqs": []}, #* ItemA (BowserCastleKey) -> Outside Lower Jail (Lava) Door Top Left
@@ -82,7 +82,7 @@ edges_kpa = [
     
     {"from": {"map": "KPA_12",  "id": 0}, "to": {"map": "KPA_12",  "id": 1}, "reqs": []}, #? Lava Channel 1 Door Left -> Lava Channel 1 Door Right
     {"from": {"map": "KPA_12",  "id": 1}, "to": {"map": "KPA_12",  "id": 0}, "reqs": []}, #? Lava Channel 1 Door Right -> Lava Channel 1 Door Left
-    {"from": {"map": "KPA_12",  "id": 0}, "to": {"map": "KPA_12",  "id": 2}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 1 Door Left -> Lava Channel 1 Lava Door Left
+    {"from": {"map": "KPA_12",  "id": 0}, "to": {"map": "KPA_12",  "id": 2}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 1 Door Left -> Lava Channel 1 Lava Door Left
     {"from": {"map": "KPA_12",  "id": 2}, "to": {"map": "KPA_12",  "id": 0}, "reqs": []}, #? Lava Chmannel 1 Lava Door Left -> Lava Channel 1 Door Left
 
     # KPA_13 Lava Channel 2
@@ -90,49 +90,49 @@ edges_kpa = [
     {"from": {"map": "KPA_13",  "id": 1}, "to": {"map": "KPA_14",  "id": 0}, "reqs": []}, # Lava Channel 2 Door Right -> Lava Channel 3 Door Left
     {"from": {"map": "KPA_13",  "id": 2}, "to": {"map": "KPA_15",  "id": 0}, "reqs": []}, # Lava Channel 2 Lava Door Center -> Lava Key Room Door Left
     
-    {"from": {"map": "KPA_13",  "id": 0}, "to": {"map": "KPA_13",  "id": 1}, "reqs": [require(partner="Parakarry",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 2 Door Left -> Lava Channel 2 Door Right
-    {"from": {"map": "KPA_13",  "id": 1}, "to": {"map": "KPA_13",  "id": 0}, "reqs": [require(partner="Parakarry",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 2 Door Right -> Lava Channel 2 Door Left
-    {"from": {"map": "KPA_13",  "id": 0}, "to": {"map": "KPA_13",  "id": 2}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 2 Door Left -> Lava Channel 2 Lava Door Center
-    {"from": {"map": "KPA_13",  "id": 2}, "to": {"map": "KPA_13",  "id": 0}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 2 Lava Door Center -> Lava Channel 2 Door Left
+    {"from": {"map": "KPA_13",  "id": 0}, "to": {"map": "KPA_13",  "id": 1}, "reqs": [["Parakarry","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 2 Door Left -> Lava Channel 2 Door Right
+    {"from": {"map": "KPA_13",  "id": 1}, "to": {"map": "KPA_13",  "id": 0}, "reqs": [["Parakarry","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 2 Door Right -> Lava Channel 2 Door Left
+    {"from": {"map": "KPA_13",  "id": 0}, "to": {"map": "KPA_13",  "id": 2}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 2 Door Left -> Lava Channel 2 Lava Door Center
+    {"from": {"map": "KPA_13",  "id": 2}, "to": {"map": "KPA_13",  "id": 0}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 2 Lava Door Center -> Lava Channel 2 Door Left
 
     # KPA_14 Lava Channel 3
     {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_13",  "id": 1}, "reqs": []}, # Lava Channel 3 Door Left -> Lava Channel 2 Door Right
     {"from": {"map": "KPA_14",  "id": 1}, "to": {"map": "KPA_01",  "id": 0}, "reqs": []}, # Lava Channel 3 Door Right -> Dark Cave 1 Door Bottom Left
     {"from": {"map": "KPA_14",  "id": 2}, "to": {"map": "KPA_16",  "id": 0}, "reqs": []}, # Lava Channel 3 Lava Door Center -> Lava Control Room Lava Door Left
     
-    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 1}, "reqs": [require(item="BowserCastleKey")]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Door Right
+    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 1}, "reqs": [[{"BowserCastleKey": 2}]]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Door Right
     #! require(flag="GF_KPA16_ShutOffLava") ^ 
-    {"from": {"map": "KPA_14",  "id": 1}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 3 Door Right -> Lava Channel 3 Door Left
-    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 2}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava"),require(partner="Bow",flag="GF_KPA16_ShutOffLava"),require(partner="Parakarry",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Lava Door Center
-    {"from": {"map": "KPA_14",  "id": 2}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #? Lava Channel 3 Lava Door Center -> Lava Channel 3 Door Left
+    {"from": {"map": "KPA_14",  "id": 1}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Door Right -> Lava Channel 3 Door Left
+    {"from": {"map": "KPA_14",  "id": 0}, "to": {"map": "KPA_14",  "id": 2}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"],["Bow","GF_KPA16_ShutOffLava"],["Parakarry","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Door Left -> Lava Channel 3 Lava Door Center
+    {"from": {"map": "KPA_14",  "id": 2}, "to": {"map": "KPA_14",  "id": 0}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #? Lava Channel 3 Lava Door Center -> Lava Channel 3 Door Left
     
-    {"from": {"map": "KPA_14",  "id": 0},       "to": {"map": "KPA_14",  "id": "ItemA"}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava"),require(partner=["Kooper","Parakarry"],flag="GF_KPA16_ShutOffLava")]}, #* Lava Channel 3 Door Left -> ItemA (Mystery)
+    {"from": {"map": "KPA_14",  "id": 0},       "to": {"map": "KPA_14",  "id": "ItemA"}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"],["Kooper","Parakarry","GF_KPA16_ShutOffLava"]]}, #* Lava Channel 3 Door Left -> ItemA (Mystery)
     {"from": {"map": "KPA_14",  "id": "ItemA"}, "to": {"map": "KPA_14",  "id": 0},       "reqs": []}, #* ItemA (Mystery) -> Lava Channel 3 Door Left
-    {"from": {"map": "KPA_14",  "id": 0},       "to": {"map": "KPA_14",  "id": "ItemB"}, "reqs": [require(flag="GF_KPA16_ShutOffLava")]}, #* Lava Channel 3 Door Left -> ItemB (ThunderRage)
+    {"from": {"map": "KPA_14",  "id": 0},       "to": {"map": "KPA_14",  "id": "ItemB"}, "reqs": [["GF_KPA16_ShutOffLava"]]}, #* Lava Channel 3 Door Left -> ItemB (ThunderRage)
     {"from": {"map": "KPA_14",  "id": "ItemB"}, "to": {"map": "KPA_14",  "id": 0},       "reqs": []}, #* ItemB (ThunderRage) -> Lava Channel 3 Door Left
 
     # KPA_15 Lava Key Room
     {"from": {"map": "KPA_15",  "id": 0}, "to": {"map": "KPA_13",  "id": 2}, "reqs": []}, # Lava Key Room Door Left -> Lava Channel 2 Lava Door Center
     
-    {"from": {"map": "KPA_15",  "id": 0},        "to": {"map": "KPA_15",  "id": "ChestA"}, "reqs": [require(flag="GF_KPA16_ShutOffLava")]}, #* Lava Key Room Door Left -> ChestA (BowserCastleKey)
+    {"from": {"map": "KPA_15",  "id": 0},        "to": {"map": "KPA_15",  "id": "ChestA"}, "reqs": [["GF_KPA16_ShutOffLava"]]}, #* Lava Key Room Door Left -> ChestA (BowserCastleKey)
     {"from": {"map": "KPA_15",  "id": "ChestA"}, "to": {"map": "KPA_15",  "id": 0},        "reqs": []}, #* ChestA (BowserCastleKey) -> Lava Key Room Door Left
 
     # KPA_16 Lava Control Room
     {"from": {"map": "KPA_16",  "id": 0}, "to": {"map": "KPA_14",  "id": 2}, "reqs": []}, # Lava Control Room Lava Door Left -> Lava Channel 3 Lava Door Center
 
-    {"from": {"map": "KPA_16",  "id": 0}, "to": {"map": "KPA_16",  "id": 0}, "reqs": [require(partner="Lakilester")], "pseudoitems": ["GF_KPA16_ShutOffLava"]}, #+ Shut off Lava Control
+    {"from": {"map": "KPA_16",  "id": 0}, "to": {"map": "KPA_16",  "id": 0}, "reqs": [["Lakilester"]], "pseudoitems": ["GF_KPA16_ShutOffLava"]}, #+ Shut off Lava Control
 
     # KPA_17 Lower Jail
     {"from": {"map": "KPA_17",  "id": 0}, "to": {"map": None, "id": None}, "reqs": []},   # Lower Jail Fall From Ceiling
     {"from": {"map": "KPA_17",  "id": 1}, "to": {"map": "KPA_10",  "id": 2}, "reqs": []}, # Lower Jail Cracked Wall Right -> Outside Lower Jail (No Lava) Cracked Wall To Jail
     {"from": {"map": "KPA_17",  "id": 1}, "to": {"map": "KPA_11",  "id": 2}, "reqs": []}, # Lower Jail Cracked Wall Right -> Outside Lower Jail (Lava) Cracked Wall To Jail
     
-    {"from": {"map": "KPA_17",  "id": 0}, "to": {"map": "KPA_17",  "id": 1}, "reqs": [require(partner="Bombette")]}, #? Lower Jail Fall From Ceiling -> Lower Jail Cracked Wall Right
+    {"from": {"map": "KPA_17",  "id": 0}, "to": {"map": "KPA_17",  "id": 1}, "reqs": [["Bombette"]]}, #? Lower Jail Fall From Ceiling -> Lower Jail Cracked Wall Right
     {"from": {"map": "KPA_17",  "id": 1}, "to": {"map": "KPA_17",  "id": 0}, "reqs": []}, #? Lower Jail Cracked Wall Right -> Lower Jail Fall From Ceiling
     
-    {"from": {"map": "KPA_17",  "id": 0},        "to": {"map": "KPA_17",  "id": "CrateA"}, "reqs": [require(boots=2)]}, #* Lower Jail Fall From Ceiling -> CrateA (TastyTonic)
+    {"from": {"map": "KPA_17",  "id": 0},        "to": {"map": "KPA_17",  "id": "CrateA"}, "reqs": [["SuperBoots"]]}, #* Lower Jail Fall From Ceiling -> CrateA (TastyTonic)
     {"from": {"map": "KPA_17",  "id": "CrateA"}, "to": {"map": "KPA_17",  "id": 0},        "reqs": []}, #* CrateA (TastyTonic) -> Lower Jail Fall From Ceiling
-    {"from": {"map": "KPA_17",  "id": 0},        "to": {"map": "KPA_17",  "id": "CrateB"}, "reqs": [require(boots=2)]}, #* Lower Jail Fall From Ceiling -> CrateB (LifeShroom)
+    {"from": {"map": "KPA_17",  "id": 0},        "to": {"map": "KPA_17",  "id": "CrateB"}, "reqs": [["SuperBoots"]]}, #* Lower Jail Fall From Ceiling -> CrateB (LifeShroom)
     {"from": {"map": "KPA_17",  "id": "CrateB"}, "to": {"map": "KPA_17",  "id": 0},        "reqs": []}, #* CrateB (LifeShroom) -> Lower Jail Fall From Ceiling
 
     # KPA_32 Lower Grand Hall
@@ -205,7 +205,7 @@ edges_kpa = [
     {"from": {"map": "KPA_52",  "id": 1}, "to": {"map": "KPA_40",  "id": 0}, "reqs": []}, # Split Level Hall Door Bottom Right -> Maze Guide Room Door Left
     {"from": {"map": "KPA_52",  "id": 2}, "to": {"map": "KPA_08",  "id": 0}, "reqs": []}, # Split Level Hall Door Top Right -> Castle Key Timing Puzzle Door Left
     
-    {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 1}, "reqs": [require(item="BowserCastleKey")]}, #? Split Level Hall Door Left -> Split Level Hall Door Bottom Right
+    {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 1}, "reqs": [[{"BowserCastleKey": 3}]]}, #? Split Level Hall Door Left -> Split Level Hall Door Bottom Right
     {"from": {"map": "KPA_52",  "id": 1}, "to": {"map": "KPA_52",  "id": 0}, "reqs": []}, #? Split Level Hall Door Bottom Right -> Split Level Hall Door Left
     {"from": {"map": "KPA_52",  "id": 0}, "to": {"map": "KPA_52",  "id": 2}, "reqs": []}, #? Split Level Hall Door Left -> Split Level Hall Door Top Right
     {"from": {"map": "KPA_52",  "id": 2}, "to": {"map": "KPA_52",  "id": 0}, "reqs": []}, #? Split Level Hall Door Top Right -> Split Level Hall Door Left
@@ -251,10 +251,10 @@ edges_kpa = [
     {"from": {"map": "KPA_62",  "id": 3}, "to": {"map": "KPA_62",  "id": 1}, "reqs": []}, #? Front Door Exterior Hangar Door Bottom Left -> Front Door Exterior Door Right
     {"from": {"map": "KPA_62",  "id": 1}, "to": {"map": "KPA_62",  "id": 3}, "reqs": []}, #? Front Door Exterior Door Right -> Front Door Exterior Hangar Door Bottom Left
     {"from": {"map": "KPA_62",  "id": 0}, "to": {"map": "KPA_62",  "id": 3}, "reqs": []}, #? Front Door Exterior Front Door -> Front Door Exterior Hangar Door Bottom Left
-    {"from": {"map": "KPA_62",  "id": 3}, "to": {"map": "KPA_62",  "id": 0}, "reqs": [require(item="BowserCastleKey")]}, #? Front Door Exterior Hangar Door Bottom Left -> Front Door Exterior Front Door
+    {"from": {"map": "KPA_62",  "id": 3}, "to": {"map": "KPA_62",  "id": 0}, "reqs": [[{"BowserCastleKey": 1}]]}, #? Front Door Exterior Hangar Door Bottom Left -> Front Door Exterior Front Door
 
-    {"from": {"map": "KPA_62",  "id": 2},         "to": {"map": "KPA_62",  "id": "RBlockA"}, "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #* Front Door Exterior Lava Door Right -> RBlockA (DeepFocus3)
-    {"from": {"map": "KPA_62",  "id": "RBlockA"}, "to": {"map": "KPA_62",  "id": 2},         "reqs": [require(partner="Lakilester",flag="GF_KPA16_ShutOffLava")]}, #* RBlockA (DeepFocus3) -> Front Door Exterior Lava Door Right
+    {"from": {"map": "KPA_62",  "id": 2},         "to": {"map": "KPA_62",  "id": "RBlockA"}, "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #* Front Door Exterior Lava Door Right -> RBlockA (DeepFocus3)
+    {"from": {"map": "KPA_62",  "id": "RBlockA"}, "to": {"map": "KPA_62",  "id": 2},         "reqs": [["Lakilester","GF_KPA16_ShutOffLava"]]}, #* RBlockA (DeepFocus3) -> Front Door Exterior Lava Door Right
 
     # KPA_63 Hangar
     {"from": {"map": "KPA_63",  "id": 0}, "to": {"map": "KPA_62",  "id": 3}, "reqs": []}, # Hangar Door Bottom Right -> Front Door Exterior Hangar Door Bottom Left
@@ -276,11 +276,11 @@ edges_kpa = [
     {"from": {"map": "KPA_81",  "id": 2}, "to": {"map": "KPA_32",  "id": 0}, "reqs": []}, # Guard Door 1 Guard Door Right -> Lower Grand Hall Door Bottom Left
     {"from": {"map": "KPA_81",  "id": 3}, "to": {"map": "KPA_04",  "id": 1}, "reqs": []}, # Guard Door 1 Hidden Door Top -> Cave Exit Hidden Door Bottom
     
-    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 1}, "reqs": [require(partner="Bombette"), require(partner="Lakilester"), require(partner="Parakarry"), require(partner="Bow")]}, #? Guard Door 1 Door Left -> Guard Door 1 Fall In Trap Door
+    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 1}, "reqs": [["Bombette"], ["Lakilester"], ["Parakarry"], ["Bow"]]}, #? Guard Door 1 Door Left -> Guard Door 1 Fall In Trap Door
     {"from": {"map": "KPA_81",  "id": 1}, "to": {"map": "KPA_81",  "id": 0}, "reqs": []}, #? Guard Door 1 Fall In Trap Door -> Guard Door 1 Door Left
-    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 2}, "reqs": [require(flag="RF_Ch8_FirstGuardDoor")]}, #? Guard Door 1 Door Left -> Guard Door 1 Guard Door Right
+    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 2}, "reqs": [["RF_Ch8_FirstGuardDoor"]]}, #? Guard Door 1 Door Left -> Guard Door 1 Guard Door Right
     {"from": {"map": "KPA_81",  "id": 2}, "to": {"map": "KPA_81",  "id": 0}, "reqs": []}, #? Guard Door 1 Guard Door Right -> Guard Door 1 Door Left
-    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 3}, "reqs": [require(flag="RF_Ch8_FirstGuardDoor")]}, #? Guard Door 1 Door Left -> Guard Door 1 Hidden Door Top
+    {"from": {"map": "KPA_81",  "id": 0}, "to": {"map": "KPA_81",  "id": 3}, "reqs": [["RF_Ch8_FirstGuardDoor"]]}, #? Guard Door 1 Door Left -> Guard Door 1 Hidden Door Top
     {"from": {"map": "KPA_81",  "id": 3}, "to": {"map": "KPA_81",  "id": 0}, "reqs": [], "pseudoitems": ["RF_Ch8_FirstGuardDoor"]}, #? Guard Door 1 Hidden Door Top -> Guard Door 1 Door Left
 
     # KPA_82 Guard Door 2
@@ -367,7 +367,7 @@ edges_kpa = [
     
     {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "YBlockA"},       "reqs": []}, #* Room with Hidden Door 1 Door Left -> YBlockA (SuperShroom)
     {"from": {"map": "KPA_111", "id": "YBlockA"},       "to": {"map": "KPA_111", "id": 0},               "reqs": []}, #* YBlockA (SuperShroom) -> Room with Hidden Door 1 Door Left
-    {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Room with Hidden Door 1 Door Left -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "KPA_111", "id": 0},               "to": {"map": "KPA_111", "id": "HiddenYBlockA"}, "reqs": [["Watt","RF_HiddenBlocksVisible"]]}, #* Room with Hidden Door 1 Door Left -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "KPA_111", "id": "HiddenYBlockA"}, "to": {"map": "KPA_111", "id": 0},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> Room with Hidden Door 1 Door Left
 
     # KPA_112 Hidden Passage 1
@@ -382,7 +382,7 @@ edges_kpa = [
     {"from": {"map": "KPA_113", "id": 1}, "to": {"map": "KPA_82",  "id": 0}, "reqs": []}, # Room with Hidden Door 2 Door Right -> Guard Door 2 Door Left
     {"from": {"map": "KPA_113", "id": 2}, "to": {"map": "KPA_114", "id": 0}, "reqs": []}, # Room with Hidden Door 2 Hidden Door -> Hidden Passage 2 Hidden Door Bottom Left
     
-    {"from": {"map": "KPA_113", "id": 0}, "to": {"map": "KPA_113", "id": 1}, "reqs": [require(item="BowserCastleKey")]}, #? Room with Hidden Door 2 Door Left -> Room with Hidden Door 2 Door Right
+    {"from": {"map": "KPA_113", "id": 0}, "to": {"map": "KPA_113", "id": 1}, "reqs": [[{"BowserCastleKey": 4}]]}, #? Room with Hidden Door 2 Door Left -> Room with Hidden Door 2 Door Right
     {"from": {"map": "KPA_113", "id": 1}, "to": {"map": "KPA_113", "id": 0}, "reqs": []}, #? Room with Hidden Door 2 Door Right -> Room with Hidden Door 2 Door Left
     {"from": {"map": "KPA_113", "id": 0}, "to": {"map": "KPA_113", "id": 2}, "reqs": []}, #? Room with Hidden Door 2 Door Left -> Room with Hidden Door 2 Hidden Door
     {"from": {"map": "KPA_113", "id": 2}, "to": {"map": "KPA_113", "id": 0}, "reqs": []}, #? Room with Hidden Door 2 Hidden Door -> Room with Hidden Door 2 Door Left
@@ -449,12 +449,12 @@ edges_kpa = [
     
     {"from": {"map": "KPA_133", "id": 0}, "to": {"map": "KPA_133", "id": 1}, "reqs": []}, #? Left Water Puzzle Door Bottom Left -> Left Water Puzzle Door Bottom Right
     {"from": {"map": "KPA_133", "id": 1}, "to": {"map": "KPA_133", "id": 0}, "reqs": []}, #? Left Water Puzzle Door Bottom Right -> Left Water Puzzle Door Bottom Left
-    {"from": {"map": "KPA_133", "id": 2}, "to": {"map": "KPA_133", "id": 3}, "reqs": [require(partner="Sushie"),require(partner="Bombette")]}, #? Left Water Puzzle Door Bottom Right Upper Half -> Left Water Puzzle Door Bombable Wall
+    {"from": {"map": "KPA_133", "id": 2}, "to": {"map": "KPA_133", "id": 3}, "reqs": [["Sushie"],["Bombette"]]}, #? Left Water Puzzle Door Bottom Right Upper Half -> Left Water Puzzle Door Bombable Wall
     {"from": {"map": "KPA_133", "id": 3}, "to": {"map": "KPA_133", "id": 2}, "reqs": []}, #? Left Water Puzzle Door Bombable Wall -> Left Water Puzzle Door Bottom Right Upper Half
     {"from": {"map": "KPA_133", "id": 2}, "to": {"map": "KPA_133", "id": 1}, "reqs": []}, #? Left Water Puzzle Door Bottom Right Upper Half -> Left Water Puzzle Door Bottom Right
     {"from": {"map": "KPA_133", "id": 3}, "to": {"map": "KPA_133", "id": 1}, "reqs": []}, #? Left Water Puzzle Door Bombable Wall -> Left Water Puzzle Door Bottom Right
 
-    {"from": {"map": "KPA_133", "id": 3},       "to": {"map": "KPA_133", "id": "ItemA"}, "reqs": [require(partner="Sushie")]}, #* Left Water Puzzle Door Bombable Wall -> ItemA (BowserCastleKey)
+    {"from": {"map": "KPA_133", "id": 3},       "to": {"map": "KPA_133", "id": "ItemA"}, "reqs": [["Sushie"]]}, #* Left Water Puzzle Door Bombable Wall -> ItemA (BowserCastleKey)
     {"from": {"map": "KPA_133", "id": "ItemA"}, "to": {"map": "KPA_133", "id": 3},       "reqs": []}, #* ItemA (BowserCastleKey) -> Left Water Puzzle Door Bombable Wall
 
     # KPA_134 Right Water Puzzle
@@ -463,11 +463,11 @@ edges_kpa = [
     {"from": {"map": "KPA_134", "id": 2}, "to": {"map": "KPA_133", "id": 2}, "reqs": []}, # Right Water Puzzle Door Bottom Left Upper Half -> Left Water Puzzle Door Bottom Right Upper Half
     {"from": {"map": "KPA_134", "id": 3}, "to": {"map": "KPA_133", "id": 3}, "reqs": []}, # Right Water Puzzle Bombable Wall -> Left Water Puzzle Door Bombable Wall
     
-    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 1}, "reqs": [require(item="BowserCastleKey")]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Right
+    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 1}, "reqs": [[{"BowserCastleKey": 5}]]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Right
     {"from": {"map": "KPA_134", "id": 1}, "to": {"map": "KPA_134", "id": 0}, "reqs": []}, #? Right Water Puzzle Door Bottom Right -> Right Water Puzzle Door Bottom Left
-    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 2}, "reqs": [require(partner="Sushie")]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Left Upper Half
-    {"from": {"map": "KPA_134", "id": 2}, "to": {"map": "KPA_134", "id": 0}, "reqs": [require(partner="Sushie")]}, #? Right Water Puzzle Door Bottom Left Upper Half -> Right Water Puzzle Door Bottom Left
+    {"from": {"map": "KPA_134", "id": 0}, "to": {"map": "KPA_134", "id": 2}, "reqs": [["Sushie"]]}, #? Right Water Puzzle Door Bottom Left -> Right Water Puzzle Door Bottom Left Upper Half
+    {"from": {"map": "KPA_134", "id": 2}, "to": {"map": "KPA_134", "id": 0}, "reqs": [["Sushie"]]}, #? Right Water Puzzle Door Bottom Left Upper Half -> Right Water Puzzle Door Bottom Left
     
-    {"from": {"map": "KPA_134", "id": 3},               "to": {"map": "KPA_134", "id": "HiddenYBlockA"}, "reqs": [require(boots=3)]}, #* Right Water Puzzle Bombable Wall -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "KPA_134", "id": 3},               "to": {"map": "KPA_134", "id": "HiddenYBlockA"}, "reqs": [["UltraBoots"]]}, #* Right Water Puzzle Bombable Wall -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "KPA_134", "id": "HiddenYBlockA"}, "to": {"map": "KPA_134", "id": 3},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> Right Water Puzzle Bombable Wall
 ]

--- a/maps/graph_edges/edges_kzn.py
+++ b/maps/graph_edges/edges_kzn.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the KZN (Mt. Lavalava) area."""
 edges_kzn = [
     # KZN_01 Volcano Entrance
@@ -25,7 +23,7 @@ edges_kzn = [
     
     {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": []}, #? Central Cavern Exit West Upper -> Central Cavern Exit East Upper
     {"from": {"map": "KZN_03", "id": 1}, "to": {"map": "KZN_03", "id": 0}, "reqs": []}, #? Central Cavern Exit East Upper -> Central Cavern Exit West Upper
-    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 2}, "reqs": [require(flag="RF_KZN07_OpenedHammerChest")]}, #? Central Cavern Exit West Upper -> Central Cavern Exit East Lower 1 (Ultra Block)
+    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 2}, "reqs": [["RF_KZN07_OpenedHammerChest"]]}, #? Central Cavern Exit West Upper -> Central Cavern Exit East Lower 1 (Ultra Block)
     {"from": {"map": "KZN_03", "id": 2}, "to": {"map": "KZN_03", "id": 0}, "reqs": []}, #? Central Cavern Exit East Lower 1 (Ultra Block) -> Central Cavern Exit West Upper
     {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 3}, "reqs": []}, #? Central Cavern Exit West Upper -> Central Cavern Exit West Lower
     {"from": {"map": "KZN_03", "id": 3}, "to": {"map": "KZN_03", "id": 0}, "reqs": []}, #? Central Cavern Exit West Lower -> Central Cavern Exit West Upper
@@ -34,7 +32,7 @@ edges_kzn = [
     
     {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemA"},   "reqs": []}, #* Central Cavern Exit West Upper -> ItemA (FireShield)
     {"from": {"map": "KZN_03", "id": "ItemA"},   "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* ItemA (FireShield) -> Central Cavern Exit West Upper
-    {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemB"},   "reqs": [require(boots=3,partner="Kooper")]}, #* Central Cavern Exit West Upper -> ItemB (POWBlock)
+    {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemB"},   "reqs": [["Kooper","UltraHammer"]]}, #* Central Cavern Exit West Upper -> ItemB (POWBlock)
     {"from": {"map": "KZN_03", "id": "ItemB"},   "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* ItemB (POWBlock) -> Central Cavern Exit West Upper
     {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "YBlockA"}, "reqs": []}, #* Central Cavern Exit West Upper -> YBlockA (Coin)
     {"from": {"map": "KZN_03", "id": "YBlockA"}, "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Central Cavern Exit West Upper
@@ -60,23 +58,23 @@ edges_kzn = [
     {"from": {"map": "KZN_06", "id": 1}, "to": {"map": "KZN_07", "id": 0}, "reqs": []}, # Flowing Lava Puzzle Exit West -> Ultra Hammer Room Exit East
     {"from": {"map": "KZN_06", "id": 2}, "to": {"map": "KZN_08", "id": 0}, "reqs": []}, # Flowing Lava Puzzle Exit East Lower -> Dizzy Stomp Room Exit West
     
-    {"from": {"map": "KZN_06", "id": 0}, "to": {"map": "KZN_06", "id": 1}, "reqs": [require(partner=["Parakarry","Lakilester"])]}, #? Flowing Lava Puzzle Exit East Upper -> Flowing Lava Puzzle Exit West
-    {"from": {"map": "KZN_06", "id": 1}, "to": {"map": "KZN_06", "id": 0}, "reqs": [require(partner=["Parakarry","Lakilester"])]}, #? Flowing Lava Puzzle Exit West -> Flowing Lava Puzzle Exit East Upper
-    {"from": {"map": "KZN_06", "id": 0}, "to": {"map": "KZN_06", "id": 2}, "reqs": [require(flag="RF_KZN07_OpenedHammerChest")]}, #? Flowing Lava Puzzle Exit East Upper -> Flowing Lava Puzzle Exit East Lower
+    {"from": {"map": "KZN_06", "id": 0}, "to": {"map": "KZN_06", "id": 1}, "reqs": [["Parakarry","Lakilester"]]}, #? Flowing Lava Puzzle Exit East Upper -> Flowing Lava Puzzle Exit West
+    {"from": {"map": "KZN_06", "id": 1}, "to": {"map": "KZN_06", "id": 0}, "reqs": [["Parakarry","Lakilester"]]}, #? Flowing Lava Puzzle Exit West -> Flowing Lava Puzzle Exit East Upper
+    {"from": {"map": "KZN_06", "id": 0}, "to": {"map": "KZN_06", "id": 2}, "reqs": [["RF_KZN07_OpenedHammerChest"]]}, #? Flowing Lava Puzzle Exit East Upper -> Flowing Lava Puzzle Exit East Lower
     {"from": {"map": "KZN_06", "id": 2}, "to": {"map": "KZN_06", "id": 0}, "reqs": []}, #? Flowing Lava Puzzle Exit East Lower -> Flowing Lava Puzzle Exit East Upper
     
-    {"from": {"map": "KZN_06", "id": 0},               "to": {"map": "KZN_06", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Flowing Lava Puzzle Exit East Upper -> HiddenYBlockA (LifeShroom)
+    {"from": {"map": "KZN_06", "id": 0},               "to": {"map": "KZN_06", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Flowing Lava Puzzle Exit East Upper -> HiddenYBlockA (LifeShroom)
     {"from": {"map": "KZN_06", "id": "HiddenYBlockA"}, "to": {"map": "KZN_06", "id": 0},               "reqs": []}, #* HiddenYBlockA (LifeShroom) -> Flowing Lava Puzzle Exit East Upper
 
     # KZN_07 Ultra Hammer Room
     {"from": {"map": "KZN_07", "id": 0}, "to": {"map": "KZN_06", "id": 1}, "reqs": []}, # Ultra Hammer Room Exit East -> Flowing Lava Puzzle Exit West
 
-    {"from": {"map": "KZN_07", "id": 0}, "to": {"map": "KZN_07", "id": 0}, "reqs": [require(partner=["Parakarry","Lakilester"])], "pseudoitems": ["EQUIPMENT_Hammer_Progressive_3","RF_KZN07_OpenedHammerChest"]}, #+ Open Ultra Hammer Chest
+    {"from": {"map": "KZN_07", "id": 0}, "to": {"map": "KZN_07", "id": 0}, "reqs": [["Parakarry","Lakilester"]], "pseudoitems": ["EQUIPMENT_Hammer_Progressive_3","RF_KZN07_OpenedHammerChest"]}, #+ Open Ultra Hammer Chest
 
     # KZN_08 Dizzy Stomp Room
     {"from": {"map": "KZN_08", "id": 0}, "to": {"map": "KZN_06", "id": 2}, "reqs": []}, # Dizzy Stomp Room Exit West -> Flowing Lava Puzzle Exit East Lower
     
-    {"from": {"map": "KZN_08", "id": 0},        "to": {"map": "KZN_08", "id": "ChestA"}, "reqs": [require(partner=["Parakarry","Lakilester"])]}, #* Dizzy Stomp Room Exit West -> ChestA (DizzyStomp)
+    {"from": {"map": "KZN_08", "id": 0},        "to": {"map": "KZN_08", "id": "ChestA"}, "reqs": [["Parakarry","Lakilester"]]}, #* Dizzy Stomp Room Exit West -> ChestA (DizzyStomp)
     {"from": {"map": "KZN_08", "id": "ChestA"}, "to": {"map": "KZN_08", "id": 0},        "reqs": []}, #* ChestA (DizzyStomp) -> Dizzy Stomp Room Exit West
 
     # KZN_09 Zipline Cavern
@@ -88,7 +86,7 @@ edges_kzn = [
     {"from": {"map": "KZN_09", "id": 0}, "to": {"map": "KZN_09", "id": 2}, "reqs": []}, #? Zipline Cavern Exit West Upper -> Zipline Cavern Exit West Lower
     {"from": {"map": "KZN_09", "id": 1}, "to": {"map": "KZN_09", "id": 2}, "reqs": []}, #? Zipline Cavern Exit East -> Zipline Cavern Exit West Lower
     
-    {"from": {"map": "KZN_09", "id": 2},             "to": {"map": "KZN_09", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Zipline Cavern Exit West Lower -> HiddenPanel (StarPiece)
+    {"from": {"map": "KZN_09", "id": 2},             "to": {"map": "KZN_09", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Zipline Cavern Exit West Lower -> HiddenPanel (StarPiece)
     {"from": {"map": "KZN_09", "id": "HiddenPanel"}, "to": {"map": "KZN_09", "id": 2},             "reqs": []}, #* HiddenPanel (StarPiece) -> Zipline Cavern Exit West Lower
 
     # KZN_10 Descent Toward Boss
@@ -109,7 +107,7 @@ edges_kzn = [
     {"from": {"map": "KZN_17", "id": 0}, "to": {"map": "KZN_11", "id": 1}, "reqs": []}, # Spike Roller Trap Exit West -> Second Lava Lake Exit East
     {"from": {"map": "KZN_17", "id": 1}, "to": {"map": "KZN_18", "id": 0}, "reqs": []}, # Spike Roller Trap Exit East -> Boss Antechamber Exit West
     
-    {"from": {"map": "KZN_17", "id": 0}, "to": {"map": "KZN_17", "id": 1}, "reqs": [require(flag="RF_KZN07_OpenedHammerChest")]}, #? Spike Roller Trap Exit West -> Spike Roller Trap Exit East
+    {"from": {"map": "KZN_17", "id": 0}, "to": {"map": "KZN_17", "id": 1}, "reqs": [["RF_KZN07_OpenedHammerChest"]]}, #? Spike Roller Trap Exit West -> Spike Roller Trap Exit East
     {"from": {"map": "KZN_17", "id": 1}, "to": {"map": "KZN_17", "id": 0}, "reqs": []}, #? Spike Roller Trap Exit East -> Spike Roller Trap Exit West
 
     # KZN_18 Boss Antechamber
@@ -122,7 +120,7 @@ edges_kzn = [
     {"from": {"map": "KZN_18", "id": 0}, "to": {"map": "KZN_18", "id": 2}, "reqs": []}, #? Boss Antechamber Exit West -> Boss Antechamber Exit East Lower
     {"from": {"map": "KZN_18", "id": 2}, "to": {"map": "KZN_18", "id": 0}, "reqs": []}, #? Boss Antechamber Exit East Lower -> Boss Antechamber Exit West
     
-    {"from": {"map": "KZN_18", "id": 0},             "to": {"map": "KZN_18", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Boss Antechamber Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "KZN_18", "id": 0},             "to": {"map": "KZN_18", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Boss Antechamber Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "KZN_18", "id": "HiddenPanel"}, "to": {"map": "KZN_18", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Boss Antechamber Exit West
 
     # KZN_19 Boss Room

--- a/maps/graph_edges/edges_kzn.py
+++ b/maps/graph_edges/edges_kzn.py
@@ -32,7 +32,7 @@ edges_kzn = [
     
     {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemA"},   "reqs": []}, #* Central Cavern Exit West Upper -> ItemA (FireShield)
     {"from": {"map": "KZN_03", "id": "ItemA"},   "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* ItemA (FireShield) -> Central Cavern Exit West Upper
-    {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemB"},   "reqs": [["Kooper","UltraHammer"]]}, #* Central Cavern Exit West Upper -> ItemB (POWBlock)
+    {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "ItemB"},   "reqs": [["Kooper","UltraBoots"]]}, #* Central Cavern Exit West Upper -> ItemB (POWBlock)
     {"from": {"map": "KZN_03", "id": "ItemB"},   "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* ItemB (POWBlock) -> Central Cavern Exit West Upper
     {"from": {"map": "KZN_03", "id": 0},         "to": {"map": "KZN_03", "id": "YBlockA"}, "reqs": []}, #* Central Cavern Exit West Upper -> YBlockA (Coin)
     {"from": {"map": "KZN_03", "id": "YBlockA"}, "to": {"map": "KZN_03", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Central Cavern Exit West Upper

--- a/maps/graph_edges/edges_mac.py
+++ b/maps/graph_edges/edges_mac.py
@@ -66,7 +66,7 @@ edges_mac = [
                                                                                     ["MagicalSeed4"]],
                                                                            "pseudoitems": ["RF_Ch6_FlowerGateOpen"]}, #+ Plaza District Exit Left
     
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ItemA"},        "reqs": [["SuperHammer"]]}, #* Plaza District Exit Left -> ItemA (QuickChange)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ItemA"},        "reqs": [["SuperBoots"]]}, #* Plaza District Exit Left -> ItemA (QuickChange)
     {"from": {"map": "MAC_01", "id": "ItemA"},        "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ItemA (QuickChange) -> Plaza District Exit Left
     {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "GiftA"},        "reqs": [["Calculator"]]}, #* Plaza District Exit Left -> GiftA (ISpy)
     {"from": {"map": "MAC_01", "id": "GiftA"},        "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* GiftA (ISpy) -> Plaza District Exit Left

--- a/maps/graph_edges/edges_mac.py
+++ b/maps/graph_edges/edges_mac.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the MAC (Toad Town) area."""
 edges_mac = [
     # MAC_00 Gate District
@@ -10,16 +8,16 @@ edges_mac = [
     
     {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 1}, "reqs": []}, #? Gate District Exit Left -> Gate District Exit Right
     {"from": {"map": "MAC_00", "id": 1}, "to": {"map": "MAC_00", "id": 0}, "reqs": []}, #? Gate District Exit Right -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 3}, "reqs": [require(partner="Sushie")]}, #? Gate District Exit Left -> Gate District Island Pipe
-    {"from": {"map": "MAC_00", "id": 3}, "to": {"map": "MAC_00", "id": 0}, "reqs": [require(partner="Sushie")]}, #? Gate District Island Pipe -> Gate District Exit Left
+    {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 3}, "reqs": [["Sushie"]]}, #? Gate District Exit Left -> Gate District Island Pipe
+    {"from": {"map": "MAC_00", "id": 3}, "to": {"map": "MAC_00", "id": 0}, "reqs": [["Sushie"]]}, #? Gate District Island Pipe -> Gate District Exit Left
     {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 4}, "reqs": []}, #? Gate District Exit Left -> Gate District Top Green Pipe
     {"from": {"map": "MAC_00", "id": 4}, "to": {"map": "MAC_00", "id": 0}, "reqs": []}, #? Gate District Top Green Pipe -> Gate District Exit Left
     
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Gate District Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Gate District Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "MAC_00", "id": "HiddenPanel"}, "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "ItemA"},       "reqs": [require(partner="Sushie")]}, #* Gate District Exit Left -> ItemA (StarPiece)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "ItemA"},       "reqs": [["Sushie"]]}, #* Gate District Exit Left -> ItemA (StarPiece)
     {"from": {"map": "MAC_00", "id": "ItemA"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* ItemA (StarPiece) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "GiftA"},       "reqs": [require(item="Dictionary")]}, #* Gate District Exit Left -> GiftA (StarPiece)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "GiftA"},       "reqs": [["Dictionary"]]}, #* Gate District Exit Left -> GiftA (StarPiece)
     {"from": {"map": "MAC_00", "id": "GiftA"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* GiftA (StarPiece) -> Gate District Exit Left
     {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "ShopItemA"},   "reqs": []}, #* Gate District Exit Left -> ShopItemA (FrightJar)
     {"from": {"map": "MAC_00", "id": "ShopItemA"},   "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* ShopItemA (FrightJar) -> Gate District Exit Left
@@ -35,13 +33,13 @@ edges_mac = [
     {"from": {"map": "MAC_00", "id": "ShopItemF"},   "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* ShopItemF (Mushroom) -> Gate District Exit Left
     {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoA"},       "reqs": []}, #* Gate District Exit Left -> Dojo Fight A (First Degree Card)
     {"from": {"map": "MAC_00", "id": "DojoA"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight A (First Degree Card) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoB"},       "reqs": [require(starspirits=2)]}, #* Gate District Exit Left -> Dojo Fight B (Second Degree Card)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoB"},       "reqs": [[{"starspirits": 2}]]}, #* Gate District Exit Left -> Dojo Fight B (Second Degree Card)
     {"from": {"map": "MAC_00", "id": "DojoB"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight B (Second Degree Card) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoC"},       "reqs": [require(starspirits=3)]}, #* Gate District Exit Left -> Dojo Fight C (Third Degree Card)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoC"},       "reqs": [[{"starspirits": 3}]]}, #* Gate District Exit Left -> Dojo Fight C (Third Degree Card)
     {"from": {"map": "MAC_00", "id": "DojoC"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight C (Third Degree Card) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoD"},       "reqs": [require(starspirits=4)]}, #* Gate District Exit Left -> Dojo Fight D (Fourth Degree Card)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoD"},       "reqs": [[{"starspirits": 4}]]}, #* Gate District Exit Left -> Dojo Fight D (Fourth Degree Card)
     {"from": {"map": "MAC_00", "id": "DojoD"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight D (Fourth Degree Card) -> Gate District Exit Left
-    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoE"},       "reqs": [require(starspirits=5)]}, #* Gate District Exit Left -> Dojo Fight E (Diploma)
+    {"from": {"map": "MAC_00", "id": 0},             "to": {"map": "MAC_00", "id": "DojoE"},       "reqs": [[{"starspirits": 5}]]}, #* Gate District Exit Left -> Dojo Fight E (Diploma)
     {"from": {"map": "MAC_00", "id": "DojoE"},       "to": {"map": "MAC_00", "id": 0},             "reqs": []}, #* Dojo Fight E (Diploma) -> Gate District Exit Left
 
     {"from": {"map": "MAC_00", "id": 0}, "to": {"map": "MAC_00", "id": 0}, "reqs": [], "pseudoitems": ["RF_CanVisitRussT"]}, #+ Can decipher MysteryNote
@@ -59,22 +57,22 @@ edges_mac = [
     {"from": {"map": "MAC_01", "id": 2}, "to": {"map": "MAC_01", "id": 0}, "reqs": []}, #? Plaza District Exit Top -> Plaza District Exit Left
     {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 3}, "reqs": []}, #? Plaza District Exit Left -> Plaza District Exit Bottom
     {"from": {"map": "MAC_01", "id": 3}, "to": {"map": "MAC_01", "id": 0}, "reqs": []}, #? Plaza District Exit Bottom -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 5}, "reqs": [require(flag="RF_Ch6_FlowerGateOpen")]}, #? Plaza District Exit Left -> Plaza District Flower Door
+    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 5}, "reqs": [["RF_Ch6_FlowerGateOpen"]]}, #? Plaza District Exit Left -> Plaza District Flower Door
     {"from": {"map": "MAC_01", "id": 5}, "to": {"map": "MAC_01", "id": 0}, "reqs": []}, #? Plaza District Flower Door -> Plaza District Exit Left
 
-    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [require(item="MagicalSeed1"),
-                                                                                    require(item="MagicalSeed2"),
-                                                                                    require(item="MagicalSeed3"),
-                                                                                    require(item="MagicalSeed4")],
+    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [["MagicalSeed1"],
+                                                                                    ["MagicalSeed2"],
+                                                                                    ["MagicalSeed3"],
+                                                                                    ["MagicalSeed4"]],
                                                                            "pseudoitems": ["RF_Ch6_FlowerGateOpen"]}, #+ Plaza District Exit Left
     
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ItemA"},        "reqs": [require(boots=2)]}, #* Plaza District Exit Left -> ItemA (QuickChange)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ItemA"},        "reqs": [["SuperHammer"]]}, #* Plaza District Exit Left -> ItemA (QuickChange)
     {"from": {"map": "MAC_01", "id": "ItemA"},        "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ItemA (QuickChange) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "GiftA"},        "reqs": [require(item="Calculator")]}, #* Plaza District Exit Left -> GiftA (ISpy)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "GiftA"},        "reqs": [["Calculator"]]}, #* Plaza District Exit Left -> GiftA (ISpy)
     {"from": {"map": "MAC_01", "id": "GiftA"},        "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* GiftA (ISpy) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "GiftB"},        "reqs": [require(item="Mailbag")]}, #* Plaza District Exit Left -> GiftB (StarPiece)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "GiftB"},        "reqs": [["Mailbag"]]}, #* Plaza District Exit Left -> GiftB (StarPiece)
     {"from": {"map": "MAC_01", "id": "GiftB"},        "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* GiftB (StarPiece) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* Plaza District Exit Left -> Tree1_Drop1A (StarPiece)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Plaza District Exit Left -> Tree1_Drop1A (StarPiece)
     {"from": {"map": "MAC_01", "id": "Tree1_Drop1A"}, "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* Tree1_Drop1A (StarPiece) -> Plaza District Exit Left
     {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeA"},   "reqs": []}, #* Plaza District Exit Left -> ShopBadgeA (SpeedySpin)
     {"from": {"map": "MAC_01", "id": "ShopBadgeA"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeA (SpeedySpin) -> Plaza District Exit Left
@@ -84,29 +82,29 @@ edges_mac = [
     {"from": {"map": "MAC_01", "id": "ShopBadgeC"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeC (Multibounce) -> Plaza District Exit Left
     {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeD"},   "reqs": []}, #* Plaza District Exit Left -> ShopBadgeD (DDownPound)
     {"from": {"map": "MAC_01", "id": "ShopBadgeD"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeD (DDownPound) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeE"},   "reqs": [require(starspirits=1)]}, #* Plaza District Exit Left -> ShopBadgeE (DodgeMaster)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeE"},   "reqs": [[{"starspirits": 1}]]}, #* Plaza District Exit Left -> ShopBadgeE (DodgeMaster)
     {"from": {"map": "MAC_01", "id": "ShopBadgeE"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeE (DodgeMaster) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeF"},   "reqs": [require(starspirits=1)]}, #* Plaza District Exit Left -> ShopBadgeF (SleepStomp)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeF"},   "reqs": [[{"starspirits": 1}]]}, #* Plaza District Exit Left -> ShopBadgeF (SleepStomp)
     {"from": {"map": "MAC_01", "id": "ShopBadgeF"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeF (SleepStomp) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeG"},   "reqs": [require(starspirits=1)]}, #* Plaza District Exit Left -> ShopBadgeG (DoubleDip)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeG"},   "reqs": [[{"starspirits": 1}]]}, #* Plaza District Exit Left -> ShopBadgeG (DoubleDip)
     {"from": {"map": "MAC_01", "id": "ShopBadgeG"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeG (DoubleDip) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeH"},   "reqs": [require(starspirits=2)]}, #* Plaza District Exit Left -> ShopBadgeH (JumpCharge)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeH"},   "reqs": [[{"starspirits": 2}]]}, #* Plaza District Exit Left -> ShopBadgeH (JumpCharge)
     {"from": {"map": "MAC_01", "id": "ShopBadgeH"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeH (JumpCharge) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeI"},   "reqs": [require(starspirits=2)]}, #* Plaza District Exit Left -> ShopBadgeI (SpinSmash)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeI"},   "reqs": [[{"starspirits": 2}]]}, #* Plaza District Exit Left -> ShopBadgeI (SpinSmash)
     {"from": {"map": "MAC_01", "id": "ShopBadgeI"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeI (SpinSmash) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeJ"},   "reqs": [require(starspirits=2)]}, #* Plaza District Exit Left -> ShopBadgeJ (GroupFocus)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeJ"},   "reqs": [[{"starspirits": 2}]]}, #* Plaza District Exit Left -> ShopBadgeJ (GroupFocus)
     {"from": {"map": "MAC_01", "id": "ShopBadgeJ"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeJ (GroupFocus) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeK"},   "reqs": [require(starspirits=3)]}, #* Plaza District Exit Left -> ShopBadgeK (AllorNothing)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeK"},   "reqs": [[{"starspirits": 3}]]}, #* Plaza District Exit Left -> ShopBadgeK (AllorNothing)
     {"from": {"map": "MAC_01", "id": "ShopBadgeK"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeK (AllorNothing) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeL"},   "reqs": [require(starspirits=3)]}, #* Plaza District Exit Left -> ShopBadgeL (HPPlusC)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeL"},   "reqs": [[{"starspirits": 3}]]}, #* Plaza District Exit Left -> ShopBadgeL (HPPlusC)
     {"from": {"map": "MAC_01", "id": "ShopBadgeL"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeL (HPPlusC) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeM"},   "reqs": [require(starspirits=3)]}, #* Plaza District Exit Left -> ShopBadgeM (FPPlusC)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeM"},   "reqs": [[{"starspirits": 3}]]}, #* Plaza District Exit Left -> ShopBadgeM (FPPlusC)
     {"from": {"map": "MAC_01", "id": "ShopBadgeM"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeM (FPPlusC) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeN"},   "reqs": [require(starspirits=4)]}, #* Plaza District Exit Left -> ShopBadgeN (SSmashChg)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeN"},   "reqs": [[{"starspirits": 4}]]}, #* Plaza District Exit Left -> ShopBadgeN (SSmashChg)
     {"from": {"map": "MAC_01", "id": "ShopBadgeN"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeN (SSmashChg) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeO"},   "reqs": [require(starspirits=4)]}, #* Plaza District Exit Left -> ShopBadgeO (DamageDodgeA)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeO"},   "reqs": [[{"starspirits": 4}]]}, #* Plaza District Exit Left -> ShopBadgeO (DamageDodgeA)
     {"from": {"map": "MAC_01", "id": "ShopBadgeO"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeO (DamageDodgeA) -> Plaza District Exit Left
-    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeP"},   "reqs": [require(starspirits=4)]}, #* Plaza District Exit Left -> ShopBadgeP (MegaQuake)
+    {"from": {"map": "MAC_01", "id": 0},              "to": {"map": "MAC_01", "id": "ShopBadgeP"},   "reqs": [[{"starspirits": 4}]]}, #* Plaza District Exit Left -> ShopBadgeP (MegaQuake)
     {"from": {"map": "MAC_01", "id": "ShopBadgeP"},   "to": {"map": "MAC_01", "id": 0},              "reqs": []}, #* ShopBadgeP (MegaQuake) -> Plaza District Exit Left
 
     {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [], "pseudoitems": ["RF_CanReadToadTownNews"]}, #+ For Koopa Koot Favor 4_01
@@ -115,15 +113,15 @@ edges_mac = [
                                                                                                        "StarPiece_MAC_2",
                                                                                                        "StarPiece_MAC_3",
                                                                                                        "StarPiece_MAC_4"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [require(starspirits=2)], "pseudoitems": ["StarPiece_MAC_5",
+    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [[{"starspirits": 2}]], "pseudoitems": ["StarPiece_MAC_5",
                                                                                                                              "StarPiece_MAC_6",
                                                                                                                              "StarPiece_MAC_7",
                                                                                                                              "StarPiece_MAC_8"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [require(starspirits=4)], "pseudoitems": ["StarPiece_MAC_9",
+    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [[{"starspirits": 4}]], "pseudoitems": ["StarPiece_MAC_9",
                                                                                                                              "StarPiece_MAC_10",
                                                                                                                              "StarPiece_MAC_11",
                                                                                                                              "StarPiece_MAC_12"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [require(starspirits=6)], "pseudoitems": ["StarPiece_MAC_13",
+    {"from": {"map": "MAC_01", "id": 0}, "to": {"map": "MAC_01", "id": 0}, "reqs": [[{"starspirits": 6}]], "pseudoitems": ["StarPiece_MAC_13",
                                                                                                                              "StarPiece_MAC_14",
                                                                                                                              "StarPiece_MAC_15",
                                                                                                                              "StarPiece_MAC_16"]}, #+ Quizmo StarPieces
@@ -144,14 +142,14 @@ edges_mac = [
     {"from": {"map": "MAC_02", "id": 3}, "to": {"map": "MAC_02", "id": 2}, "reqs": []}, #? Southern District Exit Bottom -> Southern District Exit Top
     {"from": {"map": "MAC_02", "id": 2}, "to": {"map": "MAC_02", "id": 4}, "reqs": []}, #? Southern District Exit Top -> Southern District Open Pipe
     {"from": {"map": "MAC_02", "id": 4}, "to": {"map": "MAC_02", "id": 2}, "reqs": []}, #? Southern District Open Pipe -> Southern District Exit Top
-    {"from": {"map": "MAC_02", "id": 2}, "to": {"map": "MAC_02", "id": 5}, "reqs": [require(item="OddKey",flag="GF_MAC02_UnlockedHouse")], "pseudoitems": ["GF_MAC02_UnlockedHouse"]}, #? Southern District Exit Top -> Southern District Blue House Pipe
-    {"from": {"map": "MAC_02", "id": 5}, "to": {"map": "MAC_02", "id": 2}, "reqs": [require(item="OddKey",flag="GF_MAC02_UnlockedHouse")], "pseudoitems": ["GF_MAC02_UnlockedHouse"]}, #? Southern District Blue House Pipe -> Southern District Exit Top
+    {"from": {"map": "MAC_02", "id": 2}, "to": {"map": "MAC_02", "id": 5}, "reqs": [["OddKey","GF_MAC02_UnlockedHouse"]], "pseudoitems": ["GF_MAC02_UnlockedHouse"]}, #? Southern District Exit Top -> Southern District Blue House Pipe
+    {"from": {"map": "MAC_02", "id": 5}, "to": {"map": "MAC_02", "id": 2}, "reqs": [["OddKey","GF_MAC02_UnlockedHouse"]], "pseudoitems": ["GF_MAC02_UnlockedHouse"]}, #? Southern District Blue House Pipe -> Southern District Exit Top
     
     {"from": {"map": "MAC_02", "id": 2},             "to": {"map": "MAC_02", "id": "GiftA"},       "reqs": []}, #* Southern District Exit Top -> GiftA (MagicalSeed1)
     {"from": {"map": "MAC_02", "id": "GiftA"},       "to": {"map": "MAC_02", "id": 2},             "reqs": []}, #* GiftA (MagicalSeed1) -> Southern District Exit Top
-    {"from": {"map": "MAC_02", "id": 2},             "to": {"map": "MAC_02", "id": "GiftB"},       "reqs": [require(item="FryingPan")]}, #* Southern District Exit Top -> GiftB (Cake)
+    {"from": {"map": "MAC_02", "id": 2},             "to": {"map": "MAC_02", "id": "GiftB"},       "reqs": [["FryingPan"]]}, #* Southern District Exit Top -> GiftB (Cake)
     {"from": {"map": "MAC_02", "id": "GiftB"},       "to": {"map": "MAC_02", "id": 2},             "reqs": []}, #* GiftB (Cake) -> Southern District Exit Top
-    {"from": {"map": "MAC_02", "id": 2},             "to": {"map": "MAC_02", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Southern District Exit Top -> HiddenPanel (StarPiece)
+    {"from": {"map": "MAC_02", "id": 2},             "to": {"map": "MAC_02", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Southern District Exit Top -> HiddenPanel (StarPiece)
     {"from": {"map": "MAC_02", "id": "HiddenPanel"}, "to": {"map": "MAC_02", "id": 2},             "reqs": []}, #* HiddenPanel (StarPiece) -> Southern District Exit Top
     {"from": {"map": "MAC_02", "id": 5},             "to": {"map": "MAC_02", "id": "ItemA"},       "reqs": []}, #* Southern District Blue House Pipe -> ItemA (OddKey)
     {"from": {"map": "MAC_02", "id": "ItemA"},       "to": {"map": "MAC_02", "id": 5},             "reqs": []}, #* ItemA (OddKey) -> Southern District Blue House Pipe
@@ -163,19 +161,19 @@ edges_mac = [
     {"from": {"map": "MAC_03", "id": 1}, "to": {"map": "IWA_11", "id": 1}, "reqs": []}, # Station District Train -> Train Ride Scene Exit Left
     {"from": {"map": "MAC_03", "id": 2}, "to": {"map": "MGM_00", "id": 0}, "reqs": []}, # Station District Minigame Pipe -> Playroom Lobby Exit Pipe
     
-    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 1}, "reqs": [require(flag="GF_MAC03_BombedRock")]}, #? Station District Exit Top -> Station District Train
+    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 1}, "reqs": [["GF_MAC03_BombedRock"]]}, #? Station District Exit Top -> Station District Train
     {"from": {"map": "MAC_03", "id": 1}, "to": {"map": "MAC_03", "id": 0}, "reqs": [], "pseudoitems": ["GF_MAC03_BombedRock"]}, #? Station District Train -> Station District Exit Top
-    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 2}, "reqs": [can_shake_trees]}, #? Station District Exit Top -> Station District Minigame Pipe
+    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 2}, "reqs": [["can_shake_trees"]]}, #? Station District Exit Top -> Station District Minigame Pipe
     {"from": {"map": "MAC_03", "id": 2}, "to": {"map": "MAC_03", "id": 0}, "reqs": []}, #? Station District Minigame Pipe -> Station District Exit Top
     
-    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "GiftA"},       "reqs": [require(item="Letter20")]}, #* Station District Exit Top -> GiftA (Letter21)
+    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "GiftA"},       "reqs": [["Letter20"]]}, #* Station District Exit Top -> GiftA (Letter21)
     {"from": {"map": "MAC_03", "id": "GiftA"},       "to": {"map": "MAC_03", "id": 0},             "reqs": []}, #* GiftA (Letter21) -> Station District Exit Top
-    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "GiftB"},       "reqs": [require(item="Letter22")]}, #* Station District Exit Top -> GiftB (Letter23)
+    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "GiftB"},       "reqs": [["Letter22"]]}, #* Station District Exit Top -> GiftB (Letter23)
     {"from": {"map": "MAC_03", "id": "GiftB"},       "to": {"map": "MAC_03", "id": 0},             "reqs": []}, #* GiftB (Letter23) -> Station District Exit Top
-    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Station District Exit Top -> HiddenPanel (StarPiece)
+    {"from": {"map": "MAC_03", "id": 0},             "to": {"map": "MAC_03", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Station District Exit Top -> HiddenPanel (StarPiece)
     {"from": {"map": "MAC_03", "id": "HiddenPanel"}, "to": {"map": "MAC_03", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Station District Exit Top
 
-    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 0}, "reqs": [require(partner="Bombette")], "pseudoitems": ["GF_MAC03_BombedRock"]}, #+ Station District Explode the rock
+    {"from": {"map": "MAC_03", "id": 0}, "to": {"map": "MAC_03", "id": 0}, "reqs": [["Bombette"]], "pseudoitems": ["GF_MAC03_BombedRock"]}, #+ Station District Explode the rock
 
     # MAC_04 Residental District
     {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_02", "id": 0}, "reqs": []}, # Residental District Exit Right -> Southern District Exit Left
@@ -184,18 +182,18 @@ edges_mac = [
     
     {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 1}, "reqs": []}, #? Residental District Exit Right -> Residental District Exit Left
     {"from": {"map": "MAC_04", "id": 1}, "to": {"map": "MAC_04", "id": 0}, "reqs": []}, #? Residental District Exit Left -> Residental District Exit Right
-    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 2}, "reqs": [require(partner="Bow",flag="RF_ToyboxOpen")]}, #? Residental District Exit Right -> Residental District Toybox Spring    
+    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 2}, "reqs": [["Bow","RF_ToyboxOpen"]]}, #? Residental District Exit Right -> Residental District Toybox Spring    
     {"from": {"map": "MAC_04", "id": 2}, "to": {"map": "MAC_04", "id": 0}, "reqs": []}, #? Residental District Toybox Spring -> Residental District Exit Right
 
     {"from": {"map": "MAC_04", "id": 2}, "to": {"map": "MAC_04", "id": 2}, "reqs": [], "pseudoitems": ["MF_Ch4_CanThrowInTrain"]}, #+ Toybox: Can throw in ToyTrain
     
-    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemA"},     "reqs": [require(item="StoreroomKey")]}, #* Residental District Exit Right -> ItemA (SnowmanDoll)
+    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemA"},     "reqs": [["StoreroomKey"]]}, #* Residental District Exit Right -> ItemA (SnowmanDoll)
     {"from": {"map": "MAC_04", "id": "ItemA"},     "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ItemA (SnowmanDoll) -> Residental District Exit Right
-    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemB"},     "reqs": [require(item="StoreroomKey")]}, #* Residental District Exit Right -> ItemB (VoltShroom)
+    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemB"},     "reqs": [["StoreroomKey"]]}, #* Residental District Exit Right -> ItemB (VoltShroom)
     {"from": {"map": "MAC_04", "id": "ItemB"},     "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ItemB (VoltShroom) -> Residental District Exit Right
-    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemC"},     "reqs": [require(item="StoreroomKey")]}, #* Residental District Exit Right -> ItemC (ToyTrain)
+    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemC"},     "reqs": [["StoreroomKey"]]}, #* Residental District Exit Right -> ItemC (ToyTrain)
     {"from": {"map": "MAC_04", "id": "ItemC"},     "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ItemC (ToyTrain) -> Residental District Exit Right
-    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemD"},     "reqs": [require(item="StoreroomKey")]}, #* Residental District Exit Right -> ItemD (DizzyDial)
+    {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ItemD"},     "reqs": [["StoreroomKey"]]}, #* Residental District Exit Right -> ItemD (DizzyDial)
     {"from": {"map": "MAC_04", "id": "ItemD"},     "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ItemD (DizzyDial) -> Residental District Exit Right
     {"from": {"map": "MAC_04", "id": 0},           "to": {"map": "MAC_04", "id": "ShopItemA"}, "reqs": []}, #* Residental District Exit Right -> ShopItemA (StoneCap)
     {"from": {"map": "MAC_04", "id": "ShopItemA"}, "to": {"map": "MAC_04", "id": 0},           "reqs": []}, #* ShopItemA (StoneCap) -> Residental District Exit Right
@@ -214,15 +212,15 @@ edges_mac = [
                                                                                                        "StarPiece_MAC_2",
                                                                                                        "StarPiece_MAC_3",
                                                                                                        "StarPiece_MAC_4"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [require(starspirits=2)], "pseudoitems": ["StarPiece_MAC_5",
+    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [[{"starspirits": 2}]], "pseudoitems": ["StarPiece_MAC_5",
                                                                                                                              "StarPiece_MAC_6",
                                                                                                                              "StarPiece_MAC_7",
                                                                                                                              "StarPiece_MAC_8"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [require(starspirits=4)], "pseudoitems": ["StarPiece_MAC_9",
+    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [[{"starspirits": 4}]], "pseudoitems": ["StarPiece_MAC_9",
                                                                                                                              "StarPiece_MAC_10",
                                                                                                                              "StarPiece_MAC_11",
                                                                                                                              "StarPiece_MAC_12"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [require(starspirits=6)], "pseudoitems": ["StarPiece_MAC_13",
+    {"from": {"map": "MAC_04", "id": 0}, "to": {"map": "MAC_04", "id": 0}, "reqs": [[{"starspirits": 6}]], "pseudoitems": ["StarPiece_MAC_13",
                                                                                                                              "StarPiece_MAC_14",
                                                                                                                              "StarPiece_MAC_15",
                                                                                                                              "StarPiece_MAC_16"]}, #+ Quizmo StarPieces
@@ -232,31 +230,31 @@ edges_mac = [
     {"from": {"map": "MAC_05", "id": 1}, "to": {"map": "MAC_06", "id": 0}, "reqs": []}, # Port District Ride Whale -> Ride Whale (Toad Town)
     {"from": {"map": "MAC_05", "id": 3}, "to": {"map": "KGR_01", "id": 0}, "reqs": []}, # Port District Enter Whale -> Whale Mouth Exit Left
     
-    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 1}, "reqs": [require(flag="RF_CanRideWhale")]}, #? Port District Exit Right -> Port District Ride Whale
+    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 1}, "reqs": [["RF_CanRideWhale"]]}, #? Port District Exit Right -> Port District Ride Whale
     {"from": {"map": "MAC_05", "id": 1}, "to": {"map": "MAC_05", "id": 0}, "reqs": []}, #? Port District Ride Whale -> Port District Exit Right
-    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 3}, "reqs": [require(hammer=1, boots=2, partner="Bombette")]}, #? Port District Exit Right -> Port District Enter Whale
+    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 3}, "reqs": [["Hammer","SuperBoots","Bombette"]]}, #? Port District Exit Right -> Port District Enter Whale
     {"from": {"map": "MAC_05", "id": 3}, "to": {"map": "MAC_05", "id": 0}, "reqs": []}, #? Port District Enter Whale -> Port District Exit Right
     
     {"from": {"map": "MAC_05", "id": 0},             "to": {"map": "MAC_05", "id": "GiftA"},       "reqs": []}, #* Port District Exit Right -> GiftA (Lyrics)
     {"from": {"map": "MAC_05", "id": "GiftA"},       "to": {"map": "MAC_05", "id": 0},             "reqs": []}, #* GiftA (Lyrics) -> Port District Exit Right
-    {"from": {"map": "MAC_05", "id": 0},             "to": {"map": "MAC_05", "id": "GiftB"},       "reqs": [require(item="Melody")]}, #* Port District Exit Right -> GiftB (AttackFXD)
+    {"from": {"map": "MAC_05", "id": 0},             "to": {"map": "MAC_05", "id": "GiftB"},       "reqs": [["Melody"]]}, #* Port District Exit Right -> GiftB (AttackFXD)
     {"from": {"map": "MAC_05", "id": "GiftB"},       "to": {"map": "MAC_05", "id": 0},             "reqs": []}, #* GiftB (AttackFXD) -> Port District Exit Right
-    {"from": {"map": "MAC_05", "id": 0},             "to": {"map": "MAC_05", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Port District Exit Right -> HiddenPanel (StarPiece)
+    {"from": {"map": "MAC_05", "id": 0},             "to": {"map": "MAC_05", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Port District Exit Right -> HiddenPanel (StarPiece)
     {"from": {"map": "MAC_05", "id": "HiddenPanel"}, "to": {"map": "MAC_05", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Port District Exit Right
 
     {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_MAC_1",
                                                                                                        "StarPiece_MAC_2",
                                                                                                        "StarPiece_MAC_3",
                                                                                                        "StarPiece_MAC_4"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [require(starspirits=2)], "pseudoitems": ["StarPiece_MAC_5",
+    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [[{"starspirits": 2}]], "pseudoitems": ["StarPiece_MAC_5",
                                                                                                                              "StarPiece_MAC_6",
                                                                                                                              "StarPiece_MAC_7",
                                                                                                                              "StarPiece_MAC_8"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [require(starspirits=4)], "pseudoitems": ["StarPiece_MAC_9",
+    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [[{"starspirits": 4}]], "pseudoitems": ["StarPiece_MAC_9",
                                                                                                                              "StarPiece_MAC_10",
                                                                                                                              "StarPiece_MAC_11",
                                                                                                                              "StarPiece_MAC_12"]}, #+ Quizmo StarPieces
-    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [require(starspirits=6)], "pseudoitems": ["StarPiece_MAC_13",
+    {"from": {"map": "MAC_05", "id": 0}, "to": {"map": "MAC_05", "id": 0}, "reqs": [[{"starspirits": 6}]], "pseudoitems": ["StarPiece_MAC_13",
                                                                                                                              "StarPiece_MAC_14",
                                                                                                                              "StarPiece_MAC_15",
                                                                                                                              "StarPiece_MAC_16"]}, #+ Quizmo StarPieces

--- a/maps/graph_edges/edges_mim.py
+++ b/maps/graph_edges/edges_mim.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the MIM (Forever Forest) area."""
 edges_mim = [
     # MIM_01 Flower Sounds
@@ -145,7 +143,7 @@ edges_mim = [
     {"from": {"map": "MIM_11", "id": 1}, "to": {"map": "MIM_11", "id": 0}, "reqs": []}, #? Outside Boo's Mansion Entrance to Wasteland -> Outside Boo's Mansion Forever Forest Entrance
     {"from": {"map": "MIM_11", "id": 0}, "to": {"map": "MIM_11", "id": 2}, "reqs": []}, #? Outside Boo's Mansion Forever Forest Entrance -> Outside Boo's Mansion Front Door
     {"from": {"map": "MIM_11", "id": 2}, "to": {"map": "MIM_11", "id": 0}, "reqs": []}, #? Outside Boo's Mansion Front Door -> Outside Boo's Mansion Forever Forest Entrance
-    {"from": {"map": "MIM_11", "id": 0}, "to": {"map": "MIM_11", "id": 3}, "reqs": [require(flag="GF_TIK09_WarpPipe")]}, #? Outside Boo's Mansion Forever Forest Entrance -> Outside Boo's Mansion Blue Warp Pipe
+    {"from": {"map": "MIM_11", "id": 0}, "to": {"map": "MIM_11", "id": 3}, "reqs": [["GF_TIK09_WarpPipe"]]}, #? Outside Boo's Mansion Forever Forest Entrance -> Outside Boo's Mansion Blue Warp Pipe
     {"from": {"map": "MIM_11", "id": 3}, "to": {"map": "MIM_11", "id": 0}, "reqs": []}, #? Outside Boo's Mansion Blue Warp Pipe -> Outside Boo's Mansion Forever Forest Entrance
     
     {"from": {"map": "MIM_11", "id": 0},             "to": {"map": "MIM_11", "id": "YBlockA"},     "reqs": []}, #* Outside Boo's Mansion Forever Forest Entrance -> YBlockA (VoltShroom)
@@ -157,9 +155,9 @@ edges_mim = [
     {"from": {"map": "MIM_12", "id": 0}, "to": {"map": "MIM_11", "id": 1}, "reqs": []}, # Exit to Gusty Gulch Exit West -> Outside Boo's Mansion Entrance to Wasteland
     {"from": {"map": "MIM_12", "id": 1}, "to": {"map": "ARN_07", "id": 2}, "reqs": []}, # Exit to Gusty Gulch Exit East -> Windmill Exterior Exit Left
     
-    {"from": {"map": "MIM_12", "id": 0}, "to": {"map": "MIM_12", "id": 1}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #? Exit to Gusty Gulch Exit West -> Exit to Gusty Gulch Exit East
-    {"from": {"map": "MIM_12", "id": 1}, "to": {"map": "MIM_12", "id": 0}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #? Exit to Gusty Gulch Exit East -> Exit to Gusty Gulch Exit West
+    {"from": {"map": "MIM_12", "id": 0}, "to": {"map": "MIM_12", "id": 1}, "reqs": [["RF_OpenedGustyGulch"]]}, #? Exit to Gusty Gulch Exit West -> Exit to Gusty Gulch Exit East
+    {"from": {"map": "MIM_12", "id": 1}, "to": {"map": "MIM_12", "id": 0}, "reqs": [["RF_OpenedGustyGulch"]]}, #? Exit to Gusty Gulch Exit East -> Exit to Gusty Gulch Exit West
     
-    {"from": {"map": "MIM_12", "id": 1},             "to": {"map": "MIM_12", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Exit to Gusty Gulch Exit East -> HiddenPanel (StarPiece)
+    {"from": {"map": "MIM_12", "id": 1},             "to": {"map": "MIM_12", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Exit to Gusty Gulch Exit East -> HiddenPanel (StarPiece)
     {"from": {"map": "MIM_12", "id": "HiddenPanel"}, "to": {"map": "MIM_12", "id": 1},             "reqs": []}, #* HiddenPanel (StarPiece) -> Exit to Gusty Gulch Exit East
 ]

--- a/maps/graph_edges/edges_nok.py
+++ b/maps/graph_edges/edges_nok.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the NOK (Koopa Region) area."""
 edges_nok = [
     # NOK_01 Koopa Village 1
@@ -17,11 +15,11 @@ edges_nok = [
     {"from": {"map": "NOK_01", "id": "Bush4_Drop1A"},  "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* Bush4_Drop1A (KoopaLeaf) -> Koopa Village 1 Exit Left
     {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "Bush5_Drop1A"},  "reqs": []}, #* Koopa Village 1 Exit Left -> Bush5_Drop1A (Coin)
     {"from": {"map": "NOK_01", "id": "Bush5_Drop1A"},  "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* Bush5_Drop1A (Coin) -> Koopa Village 1 Exit Left
-    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "Bush6A_Drop1A"}, "reqs": [require(favor="FAVOR_6_01_active")]}, #* Koopa Village 1 Exit Left -> Bush6A_Drop1A (KootGlasses)
+    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "Bush6A_Drop1A"}, "reqs": [["FAVOR_6_01_active"]]}, #* Koopa Village 1 Exit Left -> Bush6A_Drop1A (KootGlasses)
     {"from": {"map": "NOK_01", "id": "Bush6A_Drop1A"}, "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* Bush6A_Drop1A (KootGlasses) -> Koopa Village 1 Exit Left
-    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "Bush7A_Drop1A"}, "reqs": [require(favor="FAVOR_3_01_active")]}, #* Koopa Village 1 Exit Left -> Bush7A_Drop1A (KootEmptyWallet)
+    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "Bush7A_Drop1A"}, "reqs": [["FAVOR_3_01_active"]]}, #* Koopa Village 1 Exit Left -> Bush7A_Drop1A (KootEmptyWallet)
     {"from": {"map": "NOK_01", "id": "Bush7A_Drop1A"}, "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* Bush7A_Drop1A (KootEmptyWallet) -> Koopa Village 1 Exit Left
-    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* Koopa Village 1 Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* Koopa Village 1 Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "NOK_01", "id": "HiddenPanel"},   "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> Koopa Village 1 Exit Left
     {"from": {"map": "NOK_01", "id": 0},               "to": {"map": "NOK_01", "id": "ShopItemA"},     "reqs": []}, #* Koopa Village 1 Exit Left -> ShopItemA (DizzyDial)
     {"from": {"map": "NOK_01", "id": "ShopItemA"},     "to": {"map": "NOK_01", "id": 0},               "reqs": []}, #* ShopItemA (DizzyDial) -> Koopa Village 1 Exit Left
@@ -52,79 +50,79 @@ edges_nok = [
     
     {"from": {"map": "NOK_02", "id": 0}, "to": {"map": "NOK_02", "id": 1}, "reqs": []}, #? Koopa Village 2 Exit Left -> Koopa Village 2 Exit Top
     {"from": {"map": "NOK_02", "id": 1}, "to": {"map": "NOK_02", "id": 0}, "reqs": []}, #? Koopa Village 2 Exit Top -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0}, "to": {"map": "NOK_02", "id": 2}, "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Koopa Village 2 Exit Left -> Koopa Village 2 Blue Pipe
+    {"from": {"map": "NOK_02", "id": 0}, "to": {"map": "NOK_02", "id": 2}, "reqs": [["GF_TIK01_WarpPipes"]]}, #? Koopa Village 2 Exit Left -> Koopa Village 2 Blue Pipe
     {"from": {"map": "NOK_02", "id": 2}, "to": {"map": "NOK_02", "id": 0}, "reqs": []}, #? Koopa Village 2 Blue Pipe -> Koopa Village 2 Exit Left
     
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftA"},       "reqs": [require(favor="FAVOR_1_01_active")]}, #* Koopa Village 2 Exit Left -> GiftA (KootKoopaLegends)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftA"},       "reqs": [["FAVOR_1_01_active"]]}, #* Koopa Village 2 Exit Left -> GiftA (KootKoopaLegends)
     {"from": {"map": "NOK_02", "id": "GiftA"},       "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* GiftA (KootKoopaLegends) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "ItemA"},       "reqs": [require(flag="RF_Ch1_Fuzzies_Banished")]}, #* Koopa Village 2 Exit Left -> ItemA (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "ItemA"},       "reqs": [["RF_Ch1_Fuzzies_Banished"]]}, #* Koopa Village 2 Exit Left -> ItemA (StarPiece)
     {"from": {"map": "NOK_02", "id": "ItemA"},       "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* ItemA (StarPiece) -> Koopa Village 2 Exit Left
     {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "Bush1_Drop1"}, "reqs": []}, #* Koopa Village 2 Exit Left -> Bush1_Drop1 (KoopaLeaf)
     {"from": {"map": "NOK_02", "id": "Bush1_Drop1"}, "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* Bush1_Drop1 (KoopaLeaf) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "Partner"},     "reqs": [require(item="KooperShell")]}, #* Koopa Village 2 Exit Left -> Partner (Kooper)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "Partner"},     "reqs": [["KooperShell"]]}, #* Koopa Village 2 Exit Left -> Partner (Kooper)
     {"from": {"map": "NOK_02", "id": "Partner"},     "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* Partner (Kooper) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftD"},       "reqs": [require(item="Artifact"),require(flag="RF_Ch1_Fuzzies_Banished"),require(flag=["RF_CanVisitDesertCamp","RF_Ch2_SavedStarSpirit"])]}, #* Koopa Village 2 Exit Left -> GiftD (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftD"},       "reqs": [["Artifact"],["RF_Ch1_Fuzzies_Banished"],["RF_CanVisitDesertCamp","RF_Ch2_SavedStarSpirit"]]}, #* Koopa Village 2 Exit Left -> GiftD (StarPiece)
     {"from": {"map": "NOK_02", "id": "GiftD"},       "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* GiftD (StarPiece) -> Koopa Village 2 Exit Left
     # Koopa Koot Initial Favors (*MB_SpiritsRescued < 1)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift00"},  "reqs": [require(item="KootKoopaLegends"),require(flag="RF_Ch1_Fuzzies_Banished")], "pseudoitems": ["FAVOR_1_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift00 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift00"},  "reqs": [["KootKoopaLegends"],["RF_Ch1_Fuzzies_Banished"]], "pseudoitems": ["FAVOR_1_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift00 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift00"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift00 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift01"},  "reqs": [require(item="SleepySheep"),require(favor="FAVOR_1_01_done")], "pseudoitems": ["FAVOR_1_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift01 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift01"},  "reqs": [["SleepySheep"],["FAVOR_1_01_done"]], "pseudoitems": ["FAVOR_1_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift01 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift01"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift01 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftB"},       "reqs": [require(favor="FAVOR_1_02_done")]}, #* Koopa Village 2 Exit Left -> GiftB (SilverCredit)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftB"},       "reqs": [["FAVOR_1_02_done"]]}, #* Koopa Village 2 Exit Left -> GiftB (SilverCredit)
     {"from": {"map": "NOK_02", "id": "GiftB"},       "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* GiftB (SilverCredit) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued < 2)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift02"},  "reqs": [require(item="KootTheTape"),require(favor="FAVOR_1_02_done"),require(starspirits=1)], "pseudoitems": ["FAVOR_2_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift02 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift02"},  "reqs": [["KootTheTape"],["FAVOR_1_02_done"],[{"starspirits": 1}]], "pseudoitems": ["FAVOR_2_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift02 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift02"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift02 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift03"},  "reqs": [require(item="KoopaLeaf"),require(flag="RF_CanVisitTayceT"),require(favor="FAVOR_2_01_done"),require(starspirits=1)], "pseudoitems": ["FAVOR_2_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift03 (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift03"},  "reqs": [["KoopaLeaf"],["RF_CanVisitTayceT"],["FAVOR_2_01_done"],[{"starspirits": 1}]], "pseudoitems": ["FAVOR_2_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift03 (StarPiece)
     {"from": {"map": "NOK_02", "id": "KootGift03"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift03 (StarPiece) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift04"},  "reqs": [require(item="KootLuigiAutograph"),require(favor="FAVOR_2_02_done"),require(starspirits=1)], "pseudoitems": ["FAVOR_2_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift04 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift04"},  "reqs": [["KootLuigiAutograph"],["FAVOR_2_02_done"],[{"starspirits": 1}]], "pseudoitems": ["FAVOR_2_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift04 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift04"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift04 (Coin) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued < 3)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift05"},  "reqs": [require(item="KootEmptyWallet"),require(favor="FAVOR_2_03_done"),require(starspirits=2)], "pseudoitems": ["FAVOR_3_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift05 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift05"},  "reqs": [["KootEmptyWallet"],["FAVOR_2_03_done"],[{"starspirits": 2}]], "pseudoitems": ["FAVOR_3_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift05 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift05"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift05 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift06"},  "reqs": [require(item="TastyTonic"),require(favor="FAVOR_3_01_done"),require(starspirits=2)], "pseudoitems": ["FAVOR_3_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift06 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift06"},  "reqs": [["TastyTonic"],["FAVOR_3_01_done"],[{"starspirits": 2}]], "pseudoitems": ["FAVOR_3_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift06 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift06"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift06 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift07"},  "reqs": [require(item="KootMerluvleeAutograph"),require(favor="FAVOR_3_02_done"),require(starspirits=2)], "pseudoitems": ["FAVOR_3_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift07 (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift07"},  "reqs": [["KootMerluvleeAutograph"],["FAVOR_3_02_done"],[{"starspirits": 2}]], "pseudoitems": ["FAVOR_3_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift07 (StarPiece)
     {"from": {"map": "NOK_02", "id": "KootGift07"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift07 (StarPiece) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued < 4)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift08"},  "reqs": [require(flag="RF_CanReadToadTownNews"),require(favor="FAVOR_3_03_done"),require(starspirits=3)], "pseudoitems": ["FAVOR_4_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift08 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift08"},  "reqs": [["RF_CanReadToadTownNews"],["FAVOR_3_03_done"],[{"starspirits": 3}]], "pseudoitems": ["FAVOR_4_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift08 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift08"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift08 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift09"},  "reqs": [require(item="LifeShroom"),require(favor="FAVOR_4_01_done"),require(starspirits=3)], "pseudoitems": ["FAVOR_4_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift09 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift09"},  "reqs": [["LifeShroom"],["FAVOR_4_01_done"],[{"starspirits": 3}]], "pseudoitems": ["FAVOR_4_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift09 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift09"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift09 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftC"},       "reqs": [require(favor="FAVOR_4_02_done")]}, #* Koopa Village 2 Exit Left -> GiftC (GoldCredit)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "GiftC"},       "reqs": [["FAVOR_4_02_done"]]}, #* Koopa Village 2 Exit Left -> GiftC (GoldCredit)
     {"from": {"map": "NOK_02", "id": "GiftC"},       "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* GiftC (GoldCredit) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0A"},  "reqs": [require(item="Goomnut"),require(flag="RF_CanVisitTayceT"),require(favor="FAVOR_4_02_done"),require(starspirits=3)], "pseudoitems": ["FAVOR_4_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift0A (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0A"},  "reqs": [["Goomnut"],["RF_CanVisitTayceT"],["FAVOR_4_02_done"],[{"starspirits": 3}]], "pseudoitems": ["FAVOR_4_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift0A (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift0A"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0A (Coin) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued < 5)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0B"},  "reqs": [require(favor="FAVOR_4_03_done"),require(starspirits=4)], "pseudoitems": ["FAVOR_5_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift0B (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0B"},  "reqs": [["FAVOR_4_03_done"],[{"starspirits": 4}]], "pseudoitems": ["FAVOR_5_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift0B (StarPiece)
     {"from": {"map": "NOK_02", "id": "KootGift0B"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0B (StarPiece) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0C"},  "reqs": [require(item="KootOldPhoto"),require(favor="FAVOR_5_01_done"),require(starspirits=4)], "pseudoitems": ["FAVOR_5_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift0C (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0C"},  "reqs": [["KootOldPhoto"],["FAVOR_5_01_done"],[{"starspirits": 4}]], "pseudoitems": ["FAVOR_5_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift0C (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift0C"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0C (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0D"},  "reqs": [require(item="DriedPasta"),require(flag="RF_CanVisitTayceT"),require(favor="FAVOR_5_02_done"),require(starspirits=4)], "pseudoitems": ["FAVOR_5_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift0D (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0D"},  "reqs": [["DriedPasta"],["RF_CanVisitTayceT"],["FAVOR_5_02_done"],[{"starspirits": 4}]], "pseudoitems": ["FAVOR_5_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift0D (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift0D"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0D (Coin) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued < 6)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0E"},  "reqs": [require(item="KootGlasses"),require(favor="FAVOR_5_03_done"),require(starspirits=5)], "pseudoitems": ["FAVOR_6_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift0E (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0E"},  "reqs": [["KootGlasses"],["FAVOR_5_03_done"],[{"starspirits": 5}]], "pseudoitems": ["FAVOR_6_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift0E (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift0E"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0E (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0F"},  "reqs": [require(item="Lime"),require(favor="FAVOR_6_01_done"),require(starspirits=5)], "pseudoitems": ["FAVOR_6_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift0F (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift0F"},  "reqs": [["Lime"],["FAVOR_6_01_done"],[{"starspirits": 5}]], "pseudoitems": ["FAVOR_6_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift0F (StarPiece)
     {"from": {"map": "NOK_02", "id": "KootGift0F"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift0F (StarPiece) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift10"},  "reqs": [require(item="CakeMix"),require(flag="RF_CanVisitTayceT"),require(favor="FAVOR_6_02_done"),require(starspirits=5)], "pseudoitems": ["FAVOR_6_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift10 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift10"},  "reqs": [["CakeMix"],["RF_CanVisitTayceT"],["FAVOR_6_02_done"],[{"starspirits": 5}]], "pseudoitems": ["FAVOR_6_03_done"]}, #* Koopa Village 2 Exit Left -> KootGift10 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift10"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift10 (Coin) -> Koopa Village 2 Exit Left
     # Koopa Koot Favors (*MB_SpiritsRescued >= 6)
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift11"},  "reqs": [require(item="KootPackage"),require(favor="FAVOR_6_03_done"),require(starspirits=6)], "pseudoitems": ["FAVOR_7_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift11 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift11"},  "reqs": [["KootPackage"],["FAVOR_6_03_done"],[{"starspirits": 6}]], "pseudoitems": ["FAVOR_7_01_done"]}, #* Koopa Village 2 Exit Left -> KootGift11 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift11"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift11 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift12"},  "reqs": [require(item="Coconut"),require(favor="FAVOR_7_01_done"),require(starspirits=6)], "pseudoitems": ["FAVOR_7_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift12 (Coin)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift12"},  "reqs": [["Coconut"],["FAVOR_7_01_done"],[{"starspirits": 6}]], "pseudoitems": ["FAVOR_7_02_done"]}, #* Koopa Village 2 Exit Left -> KootGift12 (Coin)
     {"from": {"map": "NOK_02", "id": "KootGift12"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift12 (Coin) -> Koopa Village 2 Exit Left
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift13"},  "reqs": [require(item="KootRedJar"),require(favor="FAVOR_7_02_done"),require(starspirits=6)]}, #* Koopa Village 2 Exit Left -> KootGift13 (StarPiece)
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": "KootGift13"},  "reqs": [["KootRedJar"],["FAVOR_7_02_done"],[{"starspirits": 6}]]}, #* Koopa Village 2 Exit Left -> KootGift13 (StarPiece)
     {"from": {"map": "NOK_02", "id": "KootGift13"},  "to": {"map": "NOK_02", "id": 0},             "reqs": []}, #* KootGift13 (StarPiece) -> Koopa Village 2 Exit Left
     #+ Koopa Koot Favors: Active Favor Flags
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(flag="RF_Ch1_Fuzzies_Banished")], "pseudoitems": ["FAVOR_1_01_active"]}, #+ Get KootKoopaLegends from Kolorado's Wife
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_1_02_done"), require(starspirits=1)], "pseudoitems": ["FAVOR_2_01_active"]}, #+ Get KootTheTape from Goompa
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_2_02_done"), require(starspirits=1)], "pseudoitems": ["FAVOR_2_03_active"]}, #+ Get KootLuigiAutgraph from Luigi
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_2_03_done"), require(starspirits=2)], "pseudoitems": ["FAVOR_3_01_active"]}, #+ Get KootEmptyWallet from Bush
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_3_02_done"), require(starspirits=2)], "pseudoitems": ["FAVOR_3_03_active"]}, #+ Get KootMerluvleeAutograph from Merluvlee
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_5_01_done"), require(starspirits=4)], "pseudoitems": ["FAVOR_5_02_active"]}, #+ Get KootOldPhoto from Bruce
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_5_03_done"), require(starspirits=5)], "pseudoitems": ["FAVOR_6_01_active"]}, #+ Get KootOldPhoto from Bruce
-    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [require(favor="FAVOR_6_03_done"), require(starspirits=6)], "pseudoitems": ["FAVOR_7_01_active"]}, #+ Get KootOldPhoto from Bruce
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["RF_Ch1_Fuzzies_Banished"]], "pseudoitems": ["FAVOR_1_01_active"]}, #+ Get KootKoopaLegends from Kolorado's Wife
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_1_02_done"], [{"starspirits": 1}]], "pseudoitems": ["FAVOR_2_01_active"]}, #+ Get KootTheTape from Goompa
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_2_02_done"], [{"starspirits": 1}]], "pseudoitems": ["FAVOR_2_03_active"]}, #+ Get KootLuigiAutgraph from Luigi
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_2_03_done"], [{"starspirits": 2}]], "pseudoitems": ["FAVOR_3_01_active"]}, #+ Get KootEmptyWallet from Bush
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_3_02_done"], [{"starspirits": 2}]], "pseudoitems": ["FAVOR_3_03_active"]}, #+ Get KootMerluvleeAutograph from Merluvlee
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_5_01_done"], [{"starspirits": 4}]], "pseudoitems": ["FAVOR_5_02_active"]}, #+ Get KootOldPhoto from Bruce
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_5_03_done"], [{"starspirits": 5}]], "pseudoitems": ["FAVOR_6_01_active"]}, #+ Get KootOldPhoto from Bruce
+    {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0},             "reqs": [["FAVOR_6_03_done"], [{"starspirits": 6}]], "pseudoitems": ["FAVOR_7_01_active"]}, #+ Get KootOldPhoto from Bruce
 
     {"from": {"map": "NOK_02", "id": 0},             "to": {"map": "NOK_02", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_NOK_1",
                                                                                                                    "StarPiece_NOK_2",
@@ -142,13 +140,13 @@ edges_nok = [
     {"from": {"map": "NOK_03", "id": 0}, "to": {"map": "NOK_03", "id": 1}, "reqs": []}, #? Behind Koopa Village Exit Left -> Behind Koopa Village Exit Right
     {"from": {"map": "NOK_03", "id": 1}, "to": {"map": "NOK_03", "id": 0}, "reqs": []}, #? Behind Koopa Village Exit Right -> Behind Koopa Village Exit Left
     
-    {"from": {"map": "NOK_03", "id": 0},       "to": {"map": "NOK_03", "id": "ItemA"}, "reqs": [require(partner=["Kooper","Parakarry"])]}, #* Behind Koopa Village Exit Left -> ItemA (HPPlusB)
+    {"from": {"map": "NOK_03", "id": 0},       "to": {"map": "NOK_03", "id": "ItemA"}, "reqs": [["Kooper","Parakarry"]]}, #* Behind Koopa Village Exit Left -> ItemA (HPPlusB)
     {"from": {"map": "NOK_03", "id": "ItemA"}, "to": {"map": "NOK_03", "id": 0},       "reqs": []}, #* ItemA (HPPlusB) -> Behind Koopa Village Exit Left
 
     # NOK_04 Fuzzy Forest
     {"from": {"map": "NOK_04", "id": 0}, "to": {"map": "NOK_03", "id": 1}, "reqs": []}, # Fuzzy Forest Exit Left -> Behind Koopa Village Exit Right
     
-    {"from": {"map": "NOK_04", "id": 0},       "to": {"map": "NOK_04", "id": "GiftA"}, "reqs": [require(hammer=1)], "pseudoitems": ["RF_Ch1_Fuzzies_Banished"]}, #* Fuzzy Forest Exit Left -> GiftA (KooperShell)
+    {"from": {"map": "NOK_04", "id": 0},       "to": {"map": "NOK_04", "id": "GiftA"}, "reqs": [["Hammer"]], "pseudoitems": ["RF_Ch1_Fuzzies_Banished"]}, #* Fuzzy Forest Exit Left -> GiftA (KooperShell)
     {"from": {"map": "NOK_04", "id": "GiftA"}, "to": {"map": "NOK_04", "id": 0},       "reqs": []}, #* GiftA (KooperShell) -> Fuzzy Forest Exit Left
 
     # NOK_11 Pleasant Path Entry
@@ -169,14 +167,14 @@ edges_nok = [
     {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_11", "id": 1}, "reqs": []}, # Pleasant Path Bridge Exit Left -> Pleasant Path Entry Exit Right
     {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_13", "id": 0}, "reqs": []}, # Pleasant Path Bridge Exit Right -> Pleasant Crossroads Exit Left
     
-    {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_12", "id": 1}, "reqs": [require(flag="MF_NOK12_BuiltBridge")]}, #? Pleasant Path Bridge Exit Left -> Pleasant Path Bridge Exit Right
-    {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_12", "id": 0}, "reqs": [require(flag="MF_NOK12_BuiltBridge")]}, #? Pleasant Path Bridge Exit Right -> Pleasant Path Bridge Exit Left
+    {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_12", "id": 1}, "reqs": [["MF_NOK12_BuiltBridge"]]}, #? Pleasant Path Bridge Exit Left -> Pleasant Path Bridge Exit Right
+    {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_12", "id": 0}, "reqs": [["MF_NOK12_BuiltBridge"]]}, #? Pleasant Path Bridge Exit Right -> Pleasant Path Bridge Exit Left
     
-    {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_12", "id": 0}, "reqs": [can_shake_trees], "pseudoitems": ["MF_NOK12_BuiltBridge"]}, #+ Pleasant Path Bridge Exit Left
+    {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_12", "id": 0}, "reqs": [["can_shake_trees"]], "pseudoitems": ["MF_NOK12_BuiltBridge"]}, #+ Pleasant Path Bridge Exit Left
     
     {"from": {"map": "NOK_12", "id": 0}, "to": {"map": "NOK_12", "id": "YBlockA"}, "reqs": []}, #* Pleasant Path Bridge Exit Left -> YBlockA (POWBlock)
     {"from": {"map": "NOK_12", "id": "YBlockA"}, "to": {"map": "NOK_12", "id": 0}, "reqs": []}, #* YBlockA (POWBlock) -> Pleasant Path Bridge Exit Left
-    {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_12", "id": "ItemA"}, "reqs": [require(partner="Kooper")]}, #* Pleasant Path Bridge Exit Right -> ItemA (StarPiece)
+    {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_12", "id": "ItemA"}, "reqs": [["Kooper"]]}, #* Pleasant Path Bridge Exit Right -> ItemA (StarPiece)
     {"from": {"map": "NOK_12", "id": "ItemA"}, "to": {"map": "NOK_12", "id": 1}, "reqs": []}, #* ItemA (StarPiece) -> Pleasant Path Bridge Exit Right
     {"from": {"map": "NOK_12", "id": 1}, "to": {"map": "NOK_12", "id": "ItemB"}, "reqs": []}, #* Pleasant Path Bridge Exit Right -> ItemB (SleepySheep)
     {"from": {"map": "NOK_12", "id": "ItemB"}, "to": {"map": "NOK_12", "id": 1}, "reqs": []}, #* ItemB (SleepySheep) -> Pleasant Path Bridge Exit Right
@@ -191,24 +189,24 @@ edges_nok = [
     {"from": {"map": "NOK_13", "id": 0}, "to": {"map": "NOK_13", "id": 2}, "reqs": []}, #? Pleasant Crossroads Exit Left -> Pleasant Crossroads Exit Right
     {"from": {"map": "NOK_13", "id": 2}, "to": {"map": "NOK_13", "id": 0}, "reqs": []}, #? Pleasant Crossroads Exit Right -> Pleasant Crossroads Exit Left
     
-    {"from": {"map": "NOK_13", "id": 0},             "to": {"map": "NOK_13", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Pleasant Crossroads Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "NOK_13", "id": 0},             "to": {"map": "NOK_13", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Pleasant Crossroads Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "NOK_13", "id": "HiddenPanel"}, "to": {"map": "NOK_13", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Pleasant Crossroads Exit Left
     {"from": {"map": "NOK_13", "id": 0},             "to": {"map": "NOK_13", "id": "ItemA"},       "reqs": []}, #* Pleasant Crossroads Exit Left -> ItemA (HoneySyrup)
     {"from": {"map": "NOK_13", "id": "ItemA"},       "to": {"map": "NOK_13", "id": 0},             "reqs": []}, #* ItemA (HoneySyrup) -> Pleasant Crossroads Exit Left
-    {"from": {"map": "NOK_13", "id": 0},             "to": {"map": "NOK_13", "id": "RBlockA"},     "reqs": [require(hammer=1, boots=2, partner=["Kooper","Bombette"])]}, #* Pleasant Crossroads Exit Left -> RBlockA (AttackFXB)
+    {"from": {"map": "NOK_13", "id": 0},             "to": {"map": "NOK_13", "id": "RBlockA"},     "reqs": [["can_hit_grounded_blocks"]]}, #* Pleasant Crossroads Exit Left -> RBlockA (AttackFXB)
     {"from": {"map": "NOK_13", "id": "RBlockA"},     "to": {"map": "NOK_13", "id": 0},             "reqs": []}, #* RBlockA (AttackFXB) -> Pleasant Crossroads Exit Left
 
     # NOK_14 Path to Fortress 1
     {"from": {"map": "NOK_14", "id": 0}, "to": {"map": "NOK_13", "id": 2}, "reqs": []}, # Path to Fortress 1 Exit Left -> Pleasant Crossroads Exit Right
     {"from": {"map": "NOK_14", "id": 1}, "to": {"map": "NOK_15", "id": 0}, "reqs": []}, # Path to Fortress 1 Exit Right -> Path to Fortress 2 Exit Left
     
-    {"from": {"map": "NOK_14", "id": 0}, "to": {"map": "NOK_14", "id": 1}, "reqs": [require(flag="MF_NOK14_BuiltBridge")]}, #? Path to Fortress 1 Exit Left -> Path to Fortress 1 Exit Right
-    {"from": {"map": "NOK_14", "id": 1}, "to": {"map": "NOK_14", "id": 0}, "reqs": [require(flag="MF_NOK14_BuiltBridge")]}, #? Path to Fortress 1 Exit Right -> Path to Fortress 1 Exit Left
+    {"from": {"map": "NOK_14", "id": 0}, "to": {"map": "NOK_14", "id": 1}, "reqs": [["MF_NOK14_BuiltBridge"]]}, #? Path to Fortress 1 Exit Left -> Path to Fortress 1 Exit Right
+    {"from": {"map": "NOK_14", "id": 1}, "to": {"map": "NOK_14", "id": 0}, "reqs": [["MF_NOK14_BuiltBridge"]]}, #? Path to Fortress 1 Exit Right -> Path to Fortress 1 Exit Left
     
-    {"from": {"map": "NOK_14", "id": 0}, "to": {"map": "NOK_14", "id": 0}, "reqs": [require(partner="Kooper")], "pseudoitems": ["MF_NOK14_BuiltBridge"]}, #+ Path to Fortress 1 Exit Left
+    {"from": {"map": "NOK_14", "id": 0}, "to": {"map": "NOK_14", "id": 0}, "reqs": [["Kooper"]], "pseudoitems": ["MF_NOK14_BuiltBridge"]}, #+ Path to Fortress 1 Exit Left
     {"from": {"map": "NOK_14", "id": 1}, "to": {"map": "NOK_14", "id": 1}, "reqs": [], "pseudoitems": ["MF_NOK14_BuiltBridge"]}, #+ Path to Fortress 1 Exit Left
     
-    {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* Path to Fortress 1 Exit Left -> HiddenPanel (StarPiece)
+    {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* Path to Fortress 1 Exit Left -> HiddenPanel (StarPiece)
     {"from": {"map": "NOK_14", "id": "HiddenPanel"},   "to": {"map": "NOK_14", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> Path to Fortress 1 Exit Left
     {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "ItemA"},         "reqs": []}, #* Path to Fortress 1 Exit Left -> ItemA (Coin)
     {"from": {"map": "NOK_14", "id": "ItemA"},         "to": {"map": "NOK_14", "id": 0},               "reqs": []}, #* ItemA (Coin) -> Path to Fortress 1 Exit Left
@@ -220,9 +218,9 @@ edges_nok = [
     {"from": {"map": "NOK_14", "id": "ItemD"},         "to": {"map": "NOK_14", "id": 0},               "reqs": []}, #* ItemD (Coin) -> Path to Fortress 1 Exit Left
     {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "ItemE"},         "reqs": []}, #* Path to Fortress 1 Exit Left -> ItemE (Coin)
     {"from": {"map": "NOK_14", "id": "ItemE"},         "to": {"map": "NOK_14", "id": 0},               "reqs": []}, #* ItemE (Coin) -> Path to Fortress 1 Exit Left
-    {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "ItemF"},         "reqs": [require(partner="Kooper", boots=3)]}, #* Path to Fortress 1 Exit Left -> ItemF (ThunderBolt)
+    {"from": {"map": "NOK_14", "id": 0},               "to": {"map": "NOK_14", "id": "ItemF"},         "reqs": [["Kooper","UltraBoots"]]}, #* Path to Fortress 1 Exit Left -> ItemF (ThunderBolt)
     {"from": {"map": "NOK_14", "id": "ItemF"},         "to": {"map": "NOK_14", "id": 0},               "reqs": []}, #* ItemF (ThunderBolt) -> Path to Fortress 1 Exit Left
-    {"from": {"map": "NOK_14", "id": 1},               "to": {"map": "NOK_14", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Path to Fortress 1 Exit Right -> HiddenYBlockA (FireFlower)
+    {"from": {"map": "NOK_14", "id": 1},               "to": {"map": "NOK_14", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Path to Fortress 1 Exit Right -> HiddenYBlockA (FireFlower)
     {"from": {"map": "NOK_14", "id": "HiddenYBlockA"}, "to": {"map": "NOK_14", "id": 1},               "reqs": []}, #* HiddenYBlockA (FireFlower) -> Path to Fortress 1 Exit Right
 
     # NOK_15 Path to Fortress 2
@@ -234,12 +232,12 @@ edges_nok = [
 
     {"from": {"map": "NOK_15", "id": 0}, "to": {"map": "NOK_15", "id": 1}, "reqs": []}, #? Path to Fortress 2 Exit Left -> Path to Fortress 2 Exit Bottom Right
     {"from": {"map": "NOK_15", "id": 1}, "to": {"map": "NOK_15", "id": 0}, "reqs": []}, #? Path to Fortress 2 Exit Bottom Right -> Path to Fortress 2 Exit Left
-    {"from": {"map": "NOK_15", "id": 1}, "to": {"map": "NOK_15", "id": 3}, "reqs": [require(partner="Bombette")]}, #? Path to Fortress 2 Exit Bottom Right -> Path to Fortress 2 Bottom Pipe
-    {"from": {"map": "NOK_15", "id": 3}, "to": {"map": "NOK_15", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Path to Fortress 2 Bottom Pipe -> Path to Fortress 2 Exit Bottom Right
+    {"from": {"map": "NOK_15", "id": 1}, "to": {"map": "NOK_15", "id": 3}, "reqs": [["Bombette"]]}, #? Path to Fortress 2 Exit Bottom Right -> Path to Fortress 2 Bottom Pipe
+    {"from": {"map": "NOK_15", "id": 3}, "to": {"map": "NOK_15", "id": 1}, "reqs": [["Bombette"]]}, #? Path to Fortress 2 Bottom Pipe -> Path to Fortress 2 Exit Bottom Right
     {"from": {"map": "NOK_15", "id": 4}, "to": {"map": "NOK_15", "id": 2}, "reqs": []}, #? Path to Fortress 2 Top Pipe -> Path to Fortress 2 Exit Top Right
     {"from": {"map": "NOK_15", "id": 2}, "to": {"map": "NOK_15", "id": 4}, "reqs": []}, #? Path to Fortress 2 Exit Top Right -> Path to Fortress 2 Top Pipe
     {"from": {"map": "NOK_15", "id": 4}, "to": {"map": "NOK_15", "id": 1}, "reqs": []}, #? Path to Fortress 2 Top Pipe -> Path to Fortress 2 Exit Bottom Right
     
-    {"from": {"map": "NOK_15", "id": 0},              "to": {"map": "NOK_15", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* Path to Fortress 2 Exit Left -> Tree1_Drop1A (StarPiece)
+    {"from": {"map": "NOK_15", "id": 0},              "to": {"map": "NOK_15", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* Path to Fortress 2 Exit Left -> Tree1_Drop1A (StarPiece)
     {"from": {"map": "NOK_15", "id": "Tree1_Drop1A"}, "to": {"map": "NOK_15", "id": 0},              "reqs": []}, #* Tree1_Drop1A (StarPiece) -> Path to Fortress 2 Exit Left
 ]

--- a/maps/graph_edges/edges_obk.py
+++ b/maps/graph_edges/edges_obk.py
@@ -1,6 +1,3 @@
-import re
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the OBK (Boo's Mansion) area."""
 edges_obk = [
     # OBK_01 Foyer
@@ -12,7 +9,7 @@ edges_obk = [
     {"from": {"map": "OBK_01", "id": 5}, "to": {"map": "OBK_09", "id": 0}, "reqs": []}, # Foyer Third Floor Door West -> Lady Bow's Room Door South West
     {"from": {"map": "OBK_01", "id": 6}, "to": {"map": "OBK_09", "id": 1}, "reqs": []}, # Foyer Third Floor Door East -> Lady Bow's Room Door South East
     
-    {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 1}, "reqs": [require(item="BooWeight")]}, #? Foyer Front Door -> Foyer Lower Hidden Door
+    {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 1}, "reqs": [["BooWeight"]]}, #? Foyer Front Door -> Foyer Lower Hidden Door
     {"from": {"map": "OBK_01", "id": 1}, "to": {"map": "OBK_01", "id": 0}, "reqs": []}, #? Foyer Lower Hidden Door -> Foyer Front Door
     {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 2}, "reqs": []}, #? Foyer Front Door -> Foyer Lower Door
     {"from": {"map": "OBK_01", "id": 2}, "to": {"map": "OBK_01", "id": 0}, "reqs": []}, #? Foyer Lower Door -> Foyer Front Door
@@ -20,14 +17,14 @@ edges_obk = [
     {"from": {"map": "OBK_01", "id": 3}, "to": {"map": "OBK_01", "id": 0}, "reqs": []}, #? Foyer Upper Door West -> Foyer Front Door
     {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 4}, "reqs": []}, #? Foyer Front Door -> Foyer Upper Door East
     {"from": {"map": "OBK_01", "id": 4}, "to": {"map": "OBK_01", "id": 0}, "reqs": []}, #? Foyer Upper Door East -> Foyer Front Door
-    {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 5}, "reqs": [require(item="BooPortrait")]}, #? Foyer Front Door -> Foyer Third Floor Door West
+    {"from": {"map": "OBK_01", "id": 0}, "to": {"map": "OBK_01", "id": 5}, "reqs": [["BooPortrait"]]}, #? Foyer Front Door -> Foyer Third Floor Door West
     {"from": {"map": "OBK_01", "id": 5}, "to": {"map": "OBK_01", "id": 0}, "reqs": []}, #? Foyer Third Floor Door West -> Foyer Front Door
     {"from": {"map": "OBK_01", "id": 5}, "to": {"map": "OBK_01", "id": 6}, "reqs": []}, #? Foyer Third Floor Door West -> Foyer Third Floor Door East
     {"from": {"map": "OBK_01", "id": 6}, "to": {"map": "OBK_01", "id": 5}, "reqs": []}, #? Foyer Third Floor Door East -> Foyer Third Floor Door West
     
-    {"from": {"map": "OBK_01", "id": 0},             "to": {"map": "OBK_01", "id": "GiftA"},       "reqs": [require(favor="FAVOR_5_02_active")]}, #* Foyer Front Door -> GiftA (KootOldPhoto)
+    {"from": {"map": "OBK_01", "id": 0},             "to": {"map": "OBK_01", "id": "GiftA"},       "reqs": [["FAVOR_5_02_active"]]}, #* Foyer Front Door -> GiftA (KootOldPhoto)
     {"from": {"map": "OBK_01", "id": "GiftA"},       "to": {"map": "OBK_01", "id": 0},             "reqs": []}, #* GiftA (KootOldPhoto) -> Foyer Front Door
-    {"from": {"map": "OBK_01", "id": 0},             "to": {"map": "OBK_01", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Foyer Front Door -> HiddenPanel (StarPiece)
+    {"from": {"map": "OBK_01", "id": 0},             "to": {"map": "OBK_01", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Foyer Front Door -> HiddenPanel (StarPiece)
     {"from": {"map": "OBK_01", "id": "HiddenPanel"}, "to": {"map": "OBK_01", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Foyer Front Door
 
     # OBK_02 Basement Stairs
@@ -37,10 +34,10 @@ edges_obk = [
     
     {"from": {"map": "OBK_02", "id": 0}, "to": {"map": "OBK_02", "id": 1}, "reqs": []}, #? Basement Stairs Upper Door -> Basement Stairs Lower Door South
     {"from": {"map": "OBK_02", "id": 1}, "to": {"map": "OBK_02", "id": 0}, "reqs": []}, #? Basement Stairs Lower Door South -> Basement Stairs Upper Door
-    {"from": {"map": "OBK_02", "id": 0}, "to": {"map": "OBK_02", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Basement Stairs Upper Door -> Basement Stairs Bombable Wall
+    {"from": {"map": "OBK_02", "id": 0}, "to": {"map": "OBK_02", "id": 2}, "reqs": [["Bombette"]]}, #? Basement Stairs Upper Door -> Basement Stairs Bombable Wall
     {"from": {"map": "OBK_02", "id": 2}, "to": {"map": "OBK_02", "id": 0}, "reqs": []}, #? Basement Stairs Bombable Wall -> Basement Stairs Upper Door
     
-    {"from": {"map": "OBK_02", "id": 0},             "to": {"map": "OBK_02", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Basement Stairs Upper Door -> HiddenPanel (StarPiece)
+    {"from": {"map": "OBK_02", "id": 0},             "to": {"map": "OBK_02", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Basement Stairs Upper Door -> HiddenPanel (StarPiece)
     {"from": {"map": "OBK_02", "id": "HiddenPanel"}, "to": {"map": "OBK_02", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Basement Stairs Upper Door
 
     # OBK_03 Basement
@@ -50,73 +47,73 @@ edges_obk = [
     
     {"from": {"map": "OBK_03", "id": 0}, "to": {"map": "OBK_03", "id": 1}, "reqs": []}, #? Basement Upper Door North -> Basement Upper Door East
     {"from": {"map": "OBK_03", "id": 1}, "to": {"map": "OBK_03", "id": 0}, "reqs": []}, #? Basement Upper Door East -> Basement Upper Door North
-    {"from": {"map": "OBK_03", "id": 0}, "to": {"map": "OBK_03", "id": 2}, "reqs": [require(flag="MF_OBK03_HitHugeBlueSwitch")]}, #? Basement Upper Door North -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2}, "to": {"map": "OBK_03", "id": 0}, "reqs": [require(flag="MF_OBK03_HitHugeBlueSwitch")]}, #? Basement Fall From Ceiling -> Basement Upper Door North
+    {"from": {"map": "OBK_03", "id": 0}, "to": {"map": "OBK_03", "id": 2}, "reqs": [["MF_OBK03_HitHugeBlueSwitch"]]}, #? Basement Upper Door North -> Basement Fall From Ceiling
+    {"from": {"map": "OBK_03", "id": 2}, "to": {"map": "OBK_03", "id": 0}, "reqs": [["MF_OBK03_HitHugeBlueSwitch"]]}, #? Basement Fall From Ceiling -> Basement Upper Door North
     
-    {"from": {"map": "OBK_03", "id": 0},           "to": {"map": "OBK_03", "id": "CrateA"},    "reqs": [require(boots=2)]}, #* Basement Upper Door North -> CrateA (SuperShroom)
+    {"from": {"map": "OBK_03", "id": 0},           "to": {"map": "OBK_03", "id": "CrateA"},    "reqs": [["SuperBoots"]]}, #* Basement Upper Door North -> CrateA (SuperShroom)
     {"from": {"map": "OBK_03", "id": "CrateA"},    "to": {"map": "OBK_03", "id": 0},           "reqs": []}, #* CrateA (SuperShroom) -> Basement Upper Door North
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemA"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemA (Mystery)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemA"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemA (Mystery)
     {"from": {"map": "OBK_03", "id": "ShopItemA"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemA (Mystery) -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemB"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemB (StopWatch)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemB"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemB (StopWatch)
     {"from": {"map": "OBK_03", "id": "ShopItemB"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemB (StopWatch) -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemC"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemC (SnowmanDoll)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemC"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemC (SnowmanDoll)
     {"from": {"map": "OBK_03", "id": "ShopItemC"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemC (SnowmanDoll) -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemD"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemD (MapleSyrup)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemD"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemD (MapleSyrup)
     {"from": {"map": "OBK_03", "id": "ShopItemD"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemD (MapleSyrup) -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemE"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemE (LifeShroom)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemE"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemE (LifeShroom)
     {"from": {"map": "OBK_03", "id": "ShopItemE"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemE (LifeShroom) -> Basement Fall From Ceiling
-    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemF"}, "reqs": [require(flag="RF_OpenedGustyGulch")]}, #* Basement Fall From Ceiling -> ShopItemF (SuperShroom)
+    {"from": {"map": "OBK_03", "id": 2},           "to": {"map": "OBK_03", "id": "ShopItemF"}, "reqs": [["RF_OpenedGustyGulch"]]}, #* Basement Fall From Ceiling -> ShopItemF (SuperShroom)
     {"from": {"map": "OBK_03", "id": "ShopItemF"}, "to": {"map": "OBK_03", "id": 2},           "reqs": []}, #* ShopItemF (SuperShroom) -> Basement Fall From Ceiling
     
-    {"from": {"map": "OBK_03", "id": 2}, "to": {"map": "OBK_03", "id": 2}, "reqs": [require(boots=2)], "pseudoitems": ["MF_OBK03_HitHugeBlueSwitch"]}, #+ Basement Fall From Ceiling
+    {"from": {"map": "OBK_03", "id": 2}, "to": {"map": "OBK_03", "id": 2}, "reqs": [["SuperBoots"]], "pseudoitems": ["MF_OBK03_HitHugeBlueSwitch"]}, #+ Basement Fall From Ceiling
 
     # OBK_04 Super Boots Room
     {"from": {"map": "OBK_04", "id": 0}, "to": {"map": None, "id": None},  "reqs": []}, # Super Boots Room Vanishing Door
     {"from": {"map": "OBK_04", "id": 1}, "to": {"map": "OBK_03", "id": 2}, "reqs": []}, # Super Boots Room Hole Under Planks -> Basement Fall From Ceiling
     
-    {"from": {"map": "OBK_04", "id": 0}, "to": {"map": "OBK_04", "id": 1}, "reqs": [require(boots=2)]}, #? Super Boots Room Vanishing Door -> Super Boots Room Hole Under Planks
+    {"from": {"map": "OBK_04", "id": 0}, "to": {"map": "OBK_04", "id": 1}, "reqs": [["SuperBoots"]]}, #? Super Boots Room Vanishing Door -> Super Boots Room Hole Under Planks
     {"from": {"map": "OBK_04", "id": 1}, "to": {"map": "OBK_04", "id": 0}, "reqs": []}, #? Super Boots Room Hole Under Planks -> Super Boots Room Vanishing Door
     
     {"from": {"map": "OBK_04", "id": 0}, "to": {"map": "OBK_04", "id": 0}, "reqs": [], "pseudoitems": ["EQUIPMENT_Boots_Progressive_2"]}, #+ Super Boots Room Vanishing Door
     
-    {"from": {"map": "OBK_04", "id": 0},             "to": {"map": "OBK_04", "id": "CrateA"},      "reqs": [require(boots=2)]}, #* Super Boots Room Vanishing Door -> CrateA (MapleSyrup)
+    {"from": {"map": "OBK_04", "id": 0},             "to": {"map": "OBK_04", "id": "CrateA"},      "reqs": [["SuperBoots"]]}, #* Super Boots Room Vanishing Door -> CrateA (MapleSyrup)
     {"from": {"map": "OBK_04", "id": "CrateA"},      "to": {"map": "OBK_04", "id": 0},             "reqs": []}, #* CrateA (MapleSyrup) -> Super Boots Room Vanishing Door
-    {"from": {"map": "OBK_04", "id": 0},             "to": {"map": "OBK_04", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Super Boots Room Vanishing Door -> HiddenPanel (StarPiece)
+    {"from": {"map": "OBK_04", "id": 0},             "to": {"map": "OBK_04", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Super Boots Room Vanishing Door -> HiddenPanel (StarPiece)
     {"from": {"map": "OBK_04", "id": "HiddenPanel"}, "to": {"map": "OBK_04", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Super Boots Room Vanishing Door
 
     # OBK_05 Pot Room
     {"from": {"map": "OBK_05", "id": 0}, "to": {"map": "OBK_01", "id": 2}, "reqs": []}, # Pot Room Door South -> Foyer Lower Door
     {"from": {"map": "OBK_05", "id": 1}, "to": {"map": "OBK_06", "id": 0}, "reqs": []}, # Pot Room Hole Under Planks -> Library Fall From Ceiling
     
-    {"from": {"map": "OBK_05", "id": 0}, "to": {"map": "OBK_05", "id": 1}, "reqs": [require(boots=2), require(partner="Bombette")]}, #? Pot Room Door South -> Pot Room Hole Under Planks
+    {"from": {"map": "OBK_05", "id": 0}, "to": {"map": "OBK_05", "id": 1}, "reqs": [["SuperBoots"], ["Bombette"]]}, #? Pot Room Door South -> Pot Room Hole Under Planks
     {"from": {"map": "OBK_05", "id": 1}, "to": {"map": "OBK_05", "id": 0}, "reqs": []}, #? Pot Room Hole Under Planks -> Pot Room Door South
     
-    {"from": {"map": "OBK_05", "id": 0},        "to": {"map": "OBK_05", "id": "CrateA"}, "reqs": [require(boots=2)]}, #* Pot Room Door South -> CrateA (Apple)
+    {"from": {"map": "OBK_05", "id": 0},        "to": {"map": "OBK_05", "id": "CrateA"}, "reqs": [["SuperBoots"]]}, #* Pot Room Door South -> CrateA (Apple)
     {"from": {"map": "OBK_05", "id": "CrateA"}, "to": {"map": "OBK_05", "id": 0},        "reqs": []}, #* CrateA (Apple) -> Pot Room Door South
-    {"from": {"map": "OBK_05", "id": 0},        "to": {"map": "OBK_05", "id": "CrateB"}, "reqs": [require(boots=2)]}, #* Pot Room Door South -> CrateB (Apple)
+    {"from": {"map": "OBK_05", "id": 0},        "to": {"map": "OBK_05", "id": "CrateB"}, "reqs": [["SuperBoots"]]}, #* Pot Room Door South -> CrateB (Apple)
     {"from": {"map": "OBK_05", "id": "CrateB"}, "to": {"map": "OBK_05", "id": 0},        "reqs": []}, #* CrateB (Apple) -> Pot Room Door South
 
     # OBK_06 Library
     {"from": {"map": "OBK_06", "id": 0}, "to": {"map": None, "id": None},  "reqs": []}, # Library Fall From Ceiling
     {"from": {"map": "OBK_06", "id": 1}, "to": {"map": "OBK_02", "id": 2}, "reqs": []}, # Library Bombable Wall -> Basement Stairs Bombable Wall
     
-    {"from": {"map": "OBK_06", "id": 0}, "to": {"map": "OBK_06", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Library Fall From Ceiling -> Library Bombable Wall
+    {"from": {"map": "OBK_06", "id": 0}, "to": {"map": "OBK_06", "id": 1}, "reqs": [["Bombette"]]}, #? Library Fall From Ceiling -> Library Bombable Wall
     
-    {"from": {"map": "OBK_06", "id": 0},        "to": {"map": "OBK_06", "id": "CrateA"}, "reqs": [require(boots=2)]}, #* Library Fall From Ceiling -> CrateA (StarPiece)
-    {"from": {"map": "OBK_06", "id": "CrateA"}, "to": {"map": "OBK_06", "id": 1},        "reqs": [require(partner="Bombette")]}, #* CrateA (StarPiece) -> Library Bombable Wall
-    {"from": {"map": "OBK_06", "id": 0},        "to": {"map": "OBK_06", "id": "ItemA"},  "reqs": [require(partner="Parakarry")]}, #* Library Fall From Ceiling -> ItemA (BooPortrait)
-    {"from": {"map": "OBK_06", "id": "ItemA"},  "to": {"map": "OBK_06", "id": 0},        "reqs": [require(partner="Parakarry")]}, #* ItemA (BooPortrait) -> Library Fall From Ceiling
+    {"from": {"map": "OBK_06", "id": 0},        "to": {"map": "OBK_06", "id": "CrateA"}, "reqs": [["SuperBoots"]]}, #* Library Fall From Ceiling -> CrateA (StarPiece)
+    {"from": {"map": "OBK_06", "id": "CrateA"}, "to": {"map": "OBK_06", "id": 1},        "reqs": [["Bombette"]]}, #* CrateA (StarPiece) -> Library Bombable Wall
+    {"from": {"map": "OBK_06", "id": 0},        "to": {"map": "OBK_06", "id": "ItemA"},  "reqs": [["Parakarry"]]}, #* Library Fall From Ceiling -> ItemA (BooPortrait)
+    {"from": {"map": "OBK_06", "id": "ItemA"},  "to": {"map": "OBK_06", "id": 0},        "reqs": [["Parakarry"]]}, #* ItemA (BooPortrait) -> Library Fall From Ceiling
 
     # OBK_07 Record Player Room
     {"from": {"map": "OBK_07", "id": 0}, "to": {"map": "OBK_01", "id": 3}, "reqs": []}, # Record Player Room Door South -> Foyer Upper Door West
     
-    {"from": {"map": "OBK_07", "id": 0},        "to": {"map": "OBK_07", "id": "ChestA"}, "reqs": [require(item="BooRecord")]}, #* Record Player Room Door South -> ChestA (BooWeight)
+    {"from": {"map": "OBK_07", "id": 0},        "to": {"map": "OBK_07", "id": "ChestA"}, "reqs": [["BooRecord"]]}, #* Record Player Room Door South -> ChestA (BooWeight)
     {"from": {"map": "OBK_07", "id": "ChestA"}, "to": {"map": "OBK_07", "id": 0},        "reqs": []}, #* ChestA (BooWeight) -> Record Player Room Door South
 
     # OBK_08 Record Room
     {"from": {"map": "OBK_08", "id": 0}, "to": {"map": "OBK_01", "id": 4}, "reqs": []}, # Record Room Door South -> Foyer Upper Door East
     
-    {"from": {"map": "OBK_08", "id": 0},             "to": {"map": "OBK_08", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Record Room Door South -> HiddenPanel (StarPiece)
+    {"from": {"map": "OBK_08", "id": 0},             "to": {"map": "OBK_08", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Record Room Door South -> HiddenPanel (StarPiece)
     {"from": {"map": "OBK_08", "id": "HiddenPanel"}, "to": {"map": "OBK_08", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Record Room Door South
     {"from": {"map": "OBK_08", "id": 0},             "to": {"map": "OBK_08", "id": "ItemA"},       "reqs": []}, #* Record Room Door South -> ItemA (BooRecord)
     {"from": {"map": "OBK_08", "id": "ItemA"},       "to": {"map": "OBK_08", "id": 0},             "reqs": []}, #* ItemA (BooRecord) -> Record Room Door South

--- a/maps/graph_edges/edges_omo.py
+++ b/maps/graph_edges/edges_omo.py
@@ -1,6 +1,3 @@
-import re
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the OMO (Shy Guy's Toybox) area."""
 edges_omo = [
     # OMO_01 BLU Large Playroom
@@ -18,23 +15,23 @@ edges_omo = [
     {"from": {"map": "OMO_01", "id": "ItemE"},         "to": {"map": "OMO_01", "id": 0},               "reqs": []}, #* ItemE (Mushroom) -> BLU Large Playroom Exit East
     {"from": {"map": "OMO_01", "id": 0},               "to": {"map": "OMO_01", "id": "ItemF"},         "reqs": []}, #* BLU Large Playroom Exit East -> ItemF (FireFLower)
     {"from": {"map": "OMO_01", "id": "ItemF"},         "to": {"map": "OMO_01", "id": 0},               "reqs": []}, #* ItemF (FireFLower) -> BLU Large Playroom Exit East
-    {"from": {"map": "OMO_01", "id": 0},               "to": {"map": "OMO_01", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* BLU Large Playroom Exit East -> HiddenYBlockA (Mystery)
+    {"from": {"map": "OMO_01", "id": 0},               "to": {"map": "OMO_01", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* BLU Large Playroom Exit East -> HiddenYBlockA (Mystery)
     {"from": {"map": "OMO_01", "id": "HiddenYBlockA"}, "to": {"map": "OMO_01", "id": 0},               "reqs": []}, #* HiddenYBlockA (Mystery) -> BLU Large Playroom Exit East
-    {"from": {"map": "OMO_01", "id": 0},               "to": {"map": "OMO_01", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* BLU Large Playroom Exit East -> HiddenYBlockB (FrightJar)
+    {"from": {"map": "OMO_01", "id": 0},               "to": {"map": "OMO_01", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* BLU Large Playroom Exit East -> HiddenYBlockB (FrightJar)
     {"from": {"map": "OMO_01", "id": "HiddenYBlockB"}, "to": {"map": "OMO_01", "id": 0},               "reqs": []}, #* HiddenYBlockB (FrightJar) -> BLU Large Playroom Exit East
 
     # OMO_02 RED Boss Barricade
     {"from": {"map": "OMO_02", "id": 0}, "to": {"map": "OMO_10", "id": 1}, "reqs": []}, # RED Boss Barricade Exit West -> RED Station Exit East
     {"from": {"map": "OMO_02", "id": 1}, "to": {"map": "OMO_14", "id": 0}, "reqs": []}, # RED Boss Barricade Exit East -> RED Boss Antechamber Exit West
     
-    {"from": {"map": "OMO_02", "id": 0}, "to": {"map": "OMO_02", "id": 1}, "reqs": [require(partner="Bombette")]}, #? RED Boss Barricade Exit West -> RED Boss Barricade Exit East
-    {"from": {"map": "OMO_02", "id": 1}, "to": {"map": "OMO_02", "id": 0}, "reqs": [require(partner="Bombette")]}, #? RED Boss Barricade Exit East -> RED Boss Barricade Exit West
+    {"from": {"map": "OMO_02", "id": 0}, "to": {"map": "OMO_02", "id": 1}, "reqs": [["Bombette"]]}, #? RED Boss Barricade Exit West -> RED Boss Barricade Exit East
+    {"from": {"map": "OMO_02", "id": 1}, "to": {"map": "OMO_02", "id": 0}, "reqs": [["Bombette"]]}, #? RED Boss Barricade Exit East -> RED Boss Barricade Exit West
     
     {"from": {"map": "OMO_02", "id": 1},               "to": {"map": "OMO_02", "id": "YBlockA"},       "reqs": []}, #* RED Boss Barricade Exit East -> YBlockA (SleepySheep)
     {"from": {"map": "OMO_02", "id": "YBlockA"},       "to": {"map": "OMO_02", "id": 1},               "reqs": []}, #* YBlockA (SleepySheep) -> RED Boss Barricade Exit East
-    {"from": {"map": "OMO_02", "id": 1},               "to": {"map": "OMO_02", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* RED Boss Barricade Exit East -> HiddenYBlockA (Coin)
+    {"from": {"map": "OMO_02", "id": 1},               "to": {"map": "OMO_02", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* RED Boss Barricade Exit East -> HiddenYBlockA (Coin)
     {"from": {"map": "OMO_02", "id": "HiddenYBlockA"}, "to": {"map": "OMO_02", "id": 1},               "reqs": []}, #* HiddenYBlockA (Coin) -> RED Boss Barricade Exit East
-    {"from": {"map": "OMO_02", "id": 1},               "to": {"map": "OMO_02", "id": "ItemA"},         "reqs": [require(partner="Kooper",boots=3),require(hammer=1,boots=2),require(partner="Watt",flag="RF_HiddenBlocksVisible",boots=3)]}, #* RED Boss Barricade Exit East -> ItemA (ShootingStar)
+    {"from": {"map": "OMO_02", "id": 1},               "to": {"map": "OMO_02", "id": "ItemA"},         "reqs": [["Kooper","UltraBoots"],["Hammer","SuperBoots"],["can_see_hidden_blocks","UltraBoots"]]}, #* RED Boss Barricade Exit East -> ItemA (ShootingStar)
     {"from": {"map": "OMO_02", "id": "ItemA"},         "to": {"map": "OMO_02", "id": 1},               "reqs": []}, #* ItemA (ShootingStar) -> RED Boss Barricade Exit East
 
     # OMO_03 BLU Station
@@ -48,69 +45,69 @@ edges_omo = [
     {"from": {"map": "OMO_03", "id": 0}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Exit West -> BLU Station Spring to Toad Town
     {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 1}, "reqs": []}, #? BLU Station Spring to Toad Town -> BLU Station Exit East
     {"from": {"map": "OMO_03", "id": 1}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Exit East -> BLU Station Spring to Toad Town
-    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 2}, "reqs": [require(flag="MF_Ch4_CanThrowInTrain"),require(item="ToyTrain"),require(flag="RF_BlueSwitchPulled")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train West
+    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 2}, "reqs": [["MF_Ch4_CanThrowInTrain"],["ToyTrain"],["RF_BlueSwitchPulled"]]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train West
     {"from": {"map": "OMO_03", "id": 2}, "to": {"map": "OMO_03", "id": 4}, "reqs": [], "pseudoitems": ["RF_BlueSwitchPulled"]}, #? BLU Station Ride Train West -> BLU Station Spring to Toad Town
-    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 3}, "reqs": [require(flag="MF_Ch4_CanThrowInTrain"),require(item="ToyTrain")]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train East
+    {"from": {"map": "OMO_03", "id": 4}, "to": {"map": "OMO_03", "id": 3}, "reqs": [["MF_Ch4_CanThrowInTrain"],["ToyTrain"]]}, #? BLU Station Spring to Toad Town -> BLU Station Ride Train East
     {"from": {"map": "OMO_03", "id": 3}, "to": {"map": "OMO_03", "id": 4}, "reqs": []}, #? BLU Station Ride Train East -> BLU Station Spring to Toad Town
     
-    {"from": {"map": "OMO_03", "id": 4},               "to": {"map": "OMO_03", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* BLU Station Spring to Toad Town -> HiddenPanel (StarPiece)
+    {"from": {"map": "OMO_03", "id": 4},               "to": {"map": "OMO_03", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* BLU Station Spring to Toad Town -> HiddenPanel (StarPiece)
     {"from": {"map": "OMO_03", "id": "HiddenPanel"},   "to": {"map": "OMO_03", "id": 4},               "reqs": []}, #* HiddenPanel (StarPiece) -> BLU Station Spring to Toad Town
-    {"from": {"map": "OMO_03", "id": 4},               "to": {"map": "OMO_03", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* BLU Station Spring to Toad Town -> HiddenYBlockA (StoneCap)
+    {"from": {"map": "OMO_03", "id": 4},               "to": {"map": "OMO_03", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* BLU Station Spring to Toad Town -> HiddenYBlockA (StoneCap)
     {"from": {"map": "OMO_03", "id": "HiddenYBlockA"}, "to": {"map": "OMO_03", "id": 4},               "reqs": []}, #* HiddenYBlockA (StoneCap) -> BLU Station Spring to Toad Town
 
     # OMO_04 BLU Block City
     {"from": {"map": "OMO_04", "id": 0}, "to": {"map": "OMO_03", "id": 1}, "reqs": []}, # BLU Block City Exit West -> BLU Station Exit East
     
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemA"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemA (Mushroom)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemA"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemA (Mushroom)
     {"from": {"map": "OMO_04", "id": "ItemA"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemA (Mushroom) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ChestA"},  "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ChestA (StoreroomKey)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ChestA"},  "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ChestA (StoreroomKey)
     {"from": {"map": "OMO_04", "id": "ChestA"},  "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ChestA (StoreroomKey) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> YBlockA (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockA"}, "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> YBlockA (Coin)
     {"from": {"map": "OMO_04", "id": "YBlockA"}, "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> YBlockB (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockB"}, "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> YBlockB (Coin)
     {"from": {"map": "OMO_04", "id": "YBlockB"}, "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* YBlockB (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> YBlockC (ThunderBolt)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "YBlockC"}, "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> YBlockC (ThunderBolt)
     {"from": {"map": "OMO_04", "id": "YBlockC"}, "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* YBlockC (ThunderBolt) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemB"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemB (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemB"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemB (Coin)
     {"from": {"map": "OMO_04", "id": "ItemB"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemB (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemC"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemC (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemC"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemC (Coin)
     {"from": {"map": "OMO_04", "id": "ItemC"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemC (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemD"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemD (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemD"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemD (Coin)
     {"from": {"map": "OMO_04", "id": "ItemD"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemD (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemE"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemE (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemE"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemE (Coin)
     {"from": {"map": "OMO_04", "id": "ItemE"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemE (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemF"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemF (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemF"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemF (Coin)
     {"from": {"map": "OMO_04", "id": "ItemF"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemF (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemG"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemG (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemG"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemG (Coin)
     {"from": {"map": "OMO_04", "id": "ItemG"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemG (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemH"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemH (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemH"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemH (Coin)
     {"from": {"map": "OMO_04", "id": "ItemH"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemH (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemI"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemI (Coin)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemI"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemI (Coin)
     {"from": {"map": "OMO_04", "id": "ItemI"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemI (Coin) -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemJ"},   "reqs": [require(hammer=1,boots=2),require(partner="Parakarry")]}, #* BLU Block City Exit West -> ItemJ (StarPiece) on building
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemJ"},   "reqs": [["Hammer","SuperBoots"],["Parakarry"]]}, #* BLU Block City Exit West -> ItemJ (StarPiece) on building
     {"from": {"map": "OMO_04", "id": "ItemJ"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemJ (StarPiece) on building -> BLU Block City Exit West
-    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemK"},   "reqs": [require(hammer=1,boots=2)]}, #* BLU Block City Exit West -> ItemK (StarPiece)
+    {"from": {"map": "OMO_04", "id": 0},         "to": {"map": "OMO_04", "id": "ItemK"},   "reqs": [["Hammer","SuperBoots"]]}, #* BLU Block City Exit West -> ItemK (StarPiece)
     {"from": {"map": "OMO_04", "id": "ItemK"},   "to": {"map": "OMO_04", "id": 0},         "reqs": []}, #* ItemK (StarPiece) -> BLU Block City Exit West
 
     # OMO_05 PNK Gourmet Guy Crossing
     {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_17", "id": 0}, "reqs": []}, # PNK Gourmet Guy Crossing Exit East (South) -> PNK Tracks Hallway Exit West (South)
     {"from": {"map": "OMO_05", "id": 1}, "to": {"map": "OMO_17", "id": 1}, "reqs": []}, # PNK Gourmet Guy Crossing Exit East (North) -> PNK Tracks Hallway Exit West (North)
     
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 1}, "reqs": [require(flag="MF_Ch4_GaveCakeToGourmetGuy")]}, #? PNK Gourmet Guy Crossing Exit East (South) -> PNK Gourmet Guy Crossing Exit East (North)
-    {"from": {"map": "OMO_05", "id": 1}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(flag="MF_Ch4_GaveCakeToGourmetGuy")]}, #? PNK Gourmet Guy Crossing Exit East (North) -> PNK Gourmet Guy Crossing Exit East (South)
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 1}, "reqs": [["MF_Ch4_GaveCakeToGourmetGuy"]]}, #? PNK Gourmet Guy Crossing Exit East (South) -> PNK Gourmet Guy Crossing Exit East (North)
+    {"from": {"map": "OMO_05", "id": 1}, "to": {"map": "OMO_05", "id": 0}, "reqs": [["MF_Ch4_GaveCakeToGourmetGuy"]]}, #? PNK Gourmet Guy Crossing Exit East (North) -> PNK Gourmet Guy Crossing Exit East (South)
     
-    {"from": {"map": "OMO_05", "id": 0},               "to": {"map": "OMO_05", "id": "ItemA"},         "reqs": [require(flag="MF_Ch4_GaveCakeToGourmetGuy")]}, #* PNK Gourmet Guy Crossing Exit East (South) -> ItemA (Cookbook)
+    {"from": {"map": "OMO_05", "id": 0},               "to": {"map": "OMO_05", "id": "ItemA"},         "reqs": [["MF_Ch4_GaveCakeToGourmetGuy"]]}, #* PNK Gourmet Guy Crossing Exit East (South) -> ItemA (Cookbook)
     {"from": {"map": "OMO_05", "id": "ItemA"},         "to": {"map": "OMO_05", "id": 0},               "reqs": []}, #* ItemA (Cookbook) -> PNK Gourmet Guy Crossing Exit East (South)
     {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "YBlockA"},       "reqs": []}, #* PNK Gourmet Guy Crossing Exit East (North) -> YBlockA (Coin)
     {"from": {"map": "OMO_05", "id": "YBlockA"},       "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* YBlockA (Coin) -> PNK Gourmet Guy Crossing Exit East (North)
     {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "YBlockB"},       "reqs": []}, #* PNK Gourmet Guy Crossing Exit East (North) -> YBlockB (Coin)
     {"from": {"map": "OMO_05", "id": "YBlockB"},       "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* YBlockB (Coin) -> PNK Gourmet Guy Crossing Exit East (North)
-    {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockA (DizzyDial)
+    {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockA (DizzyDial)
     {"from": {"map": "OMO_05", "id": "HiddenYBlockA"}, "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* HiddenYBlockA (DizzyDial) -> PNK Gourmet Guy Crossing Exit East (North)
-    {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockB (SuperSoda)
+    {"from": {"map": "OMO_05", "id": 1},               "to": {"map": "OMO_05", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* PNK Gourmet Guy Crossing Exit East (North) -> HiddenYBlockB (SuperSoda)
     {"from": {"map": "OMO_05", "id": "HiddenYBlockB"}, "to": {"map": "OMO_05", "id": 1},               "reqs": []}, #* HiddenYBlockB (SuperSoda) -> PNK Gourmet Guy Crossing Exit East (North)
 
-    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [require(item=["Cake","CakeMix"]), require(flag="RF_CanVisitTayceT",item="Cake")], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
+    {"from": {"map": "OMO_05", "id": 0}, "to": {"map": "OMO_05", "id": 0}, "reqs": [["Cake","CakeMix"],["RF_CanVisitTayceT","Cake"]], "pseudoitems": ["MF_Ch4_GaveCakeToGourmetGuy"]}, #+ Give Cake to Gourmet Guy
 
     # OMO_06 PNK Station
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_17", "id": 2}, "reqs": []}, # PNK Station Exit West -> PNK Tracks Hallway Exit East (South)
@@ -121,16 +118,16 @@ edges_omo = [
     
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_06", "id": 2}, "reqs": []}, #? PNK Station Exit West -> PNK Station Ride Train West
     {"from": {"map": "OMO_06", "id": 2}, "to": {"map": "OMO_06", "id": 0}, "reqs": []}, #? PNK Station Ride Train West -> PNK Station Exit West
-    {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_06", "id": 3}, "reqs": [require(flag="MF_Ch4_PulledPinkSwitch")]}, #? PNK Station Exit West -> PNK Station Ride Train East
+    {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_06", "id": 3}, "reqs": [["MF_Ch4_PulledPinkSwitch"]]}, #? PNK Station Exit West -> PNK Station Ride Train East
     {"from": {"map": "OMO_06", "id": 3}, "to": {"map": "OMO_06", "id": 0}, "reqs": []}, #? PNK Station Ride Train East -> PNK Station Exit West
     {"from": {"map": "OMO_06", "id": 0}, "to": {"map": "OMO_06", "id": 4}, "reqs": []}, #? PNK Station Exit West -> PNK Station Exit East
     {"from": {"map": "OMO_06", "id": 4}, "to": {"map": "OMO_06", "id": 0}, "reqs": []}, #? PNK Station Exit East -> PNK Station Exit West
     
-    {"from": {"map": "OMO_06", "id": 0},               "to": {"map": "OMO_06", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* PNK Station Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "OMO_06", "id": 0},               "to": {"map": "OMO_06", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* PNK Station Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "OMO_06", "id": "HiddenPanel"},   "to": {"map": "OMO_06", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> PNK Station Exit West
     {"from": {"map": "OMO_06", "id": 0},               "to": {"map": "OMO_06", "id": "ChestA"},        "reqs": []}, #* PNK Station Exit West -> ChestA (Mailbag)
     {"from": {"map": "OMO_06", "id": "ChestA"},        "to": {"map": "OMO_06", "id": 0},               "reqs": []}, #* ChestA (Mailbag) -> PNK Station Exit West
-    {"from": {"map": "OMO_06", "id": 1},               "to": {"map": "OMO_06", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* PNK Station Exit West (Switch Area) -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "OMO_06", "id": 1},               "to": {"map": "OMO_06", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* PNK Station Exit West (Switch Area) -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "OMO_06", "id": "HiddenYBlockA"}, "to": {"map": "OMO_06", "id": 1},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> PNK Station Exit West (Switch Area)
 
     {"from": {"map": "OMO_06", "id": 1}, "to": {"map": "OMO_06", "id": 1}, "reqs": [], "pseudoitems": ["MF_Ch4_PulledPinkSwitch"]}, #+ Pull pink switch
@@ -138,15 +135,15 @@ edges_omo = [
     # OMO_07 PNK Playhouse
     {"from": {"map": "OMO_07", "id": 0}, "to": {"map": "OMO_06", "id": 4}, "reqs": []}, # PNK Playhouse Exit West -> PNK Station Exit East
     
-    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ItemA"},   "reqs": [require(hammer=1,boots=2)]}, #* PNK Playhouse Exit West -> ItemA (ThunderRage)
+    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ItemA"},   "reqs": [["Hammer","SuperBoots"]]}, #* PNK Playhouse Exit West -> ItemA (ThunderRage)
     {"from": {"map": "OMO_07", "id": "ItemA"},   "to": {"map": "OMO_07", "id": 0},         "reqs": []}, #* ItemA (ThunderRage) -> PNK Playhouse Exit West
-    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestA"},  "reqs": [require(hammer=1,boots=2)]}, #* PNK Playhouse Exit West -> ChestA (FryingPan)
+    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestA"},  "reqs": [["Hammer","SuperBoots"]]}, #* PNK Playhouse Exit West -> ChestA (FryingPan)
     {"from": {"map": "OMO_07", "id": "ChestA"},  "to": {"map": "OMO_07", "id": 0},         "reqs": []}, #* ChestA (FryingPan) -> PNK Playhouse Exit West
-    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestB"},  "reqs": [require(hammer=1,boots=2)]}, #* PNK Playhouse Exit West -> ChestB (DefendPlusA)
+    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestB"},  "reqs": [["Hammer","SuperBoots"]]}, #* PNK Playhouse Exit West -> ChestB (DefendPlusA)
     {"from": {"map": "OMO_07", "id": "ChestB"},  "to": {"map": "OMO_07", "id": 0},         "reqs": []}, #* ChestB (DefendPlusA) -> PNK Playhouse Exit West
-    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestC"},  "reqs": [require(hammer=1,boots=2)]}, #* PNK Playhouse Exit West -> ChestC (IcePower)
+    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "ChestC"},  "reqs": [["Hammer","SuperBoots"]]}, #* PNK Playhouse Exit West -> ChestC (IcePower)
     {"from": {"map": "OMO_07", "id": "ChestC"},  "to": {"map": "OMO_07", "id": 0},         "reqs": []}, #* ChestC (IcePower) -> PNK Playhouse Exit West
-    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2)]}, #* PNK Playhouse Exit West -> YBlockA (Coin)
+    {"from": {"map": "OMO_07", "id": 0},         "to": {"map": "OMO_07", "id": "YBlockA"}, "reqs": [["Hammer","SuperBoots"]]}, #* PNK Playhouse Exit West -> YBlockA (Coin)
     {"from": {"map": "OMO_07", "id": "YBlockA"}, "to": {"map": "OMO_07", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> PNK Playhouse Exit West
 
     # OMO_08 GRN Station
@@ -156,26 +153,26 @@ edges_omo = [
     
     {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 1}, "reqs": []}, #? GRN Station Exit East -> GRN Station Ride Train West
     {"from": {"map": "OMO_08", "id": 1}, "to": {"map": "OMO_08", "id": 0}, "reqs": []}, #? GRN Station Ride Train West -> GRN Station Exit East
-    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 2}, "reqs": [require(flag="MF_Ch4_SolvedColorPuzzle")]}, #? GRN Station Exit East -> GRN Station Ride Train East
+    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 2}, "reqs": [["MF_Ch4_SolvedColorPuzzle"]]}, #? GRN Station Exit East -> GRN Station Ride Train East
     {"from": {"map": "OMO_08", "id": 2}, "to": {"map": "OMO_08", "id": 0}, "reqs": []}, #? GRN Station Ride Train East -> GRN Station Exit East
     
-    {"from": {"map": "OMO_08", "id": 0},               "to": {"map": "OMO_08", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* GRN Station Exit East -> HiddenPanel (StarPiece)
+    {"from": {"map": "OMO_08", "id": 0},               "to": {"map": "OMO_08", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* GRN Station Exit East -> HiddenPanel (StarPiece)
     {"from": {"map": "OMO_08", "id": "HiddenPanel"},   "to": {"map": "OMO_08", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> GRN Station Exit East
-    {"from": {"map": "OMO_08", "id": 0},               "to": {"map": "OMO_08", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* GRN Station Exit East -> HiddenYBlockA (FireFlower)
+    {"from": {"map": "OMO_08", "id": 0},               "to": {"map": "OMO_08", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* GRN Station Exit East -> HiddenYBlockA (FireFlower)
     {"from": {"map": "OMO_08", "id": "HiddenYBlockA"}, "to": {"map": "OMO_08", "id": 0},               "reqs": []}, #* HiddenYBlockA (FireFlower) -> GRN Station Exit East
 
-    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": [require(flag="RF_CanVisitRussT"),require(item="MysteryNote"),require(item="Dictionary"),require(hammer=1)], "pseudoitems": ["MF_Ch4_SolvedColorPuzzle"]}, #+ Solve Color Puzzle
+    {"from": {"map": "OMO_08", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": [["RF_CanVisitRussT"],["MysteryNote"],["Dictionary"],["Hammer"]], "pseudoitems": ["MF_Ch4_SolvedColorPuzzle"]}, #+ Solve Color Puzzle
 
     # OMO_09 GRN Treadmills/Slot Machine
     {"from": {"map": "OMO_09", "id": 0}, "to": {"map": "OMO_08", "id": 0}, "reqs": []}, # GRN Treadmills/Slot Machine Exit West -> GRN Station Exit East
     
-    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemA"},  "reqs": [require(partner="Bow"),require(partner="Parakarry")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemA (SuperSoda)
+    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemA"},  "reqs": [["Bow"],["Parakarry"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemA (SuperSoda)
     {"from": {"map": "OMO_09", "id": "ItemA"},  "to": {"map": "OMO_09", "id": 0},        "reqs": []}, #* ItemA (SuperSoda) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ChestA"}, "reqs": [require(partner="Bow"),require(partner="Parakarry")]}, #* GRN Treadmills/Slot Machine Exit West -> ChestA (Dictionary)
+    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ChestA"}, "reqs": [["Bow"],["Parakarry"]]}, #* GRN Treadmills/Slot Machine Exit West -> ChestA (Dictionary)
     {"from": {"map": "OMO_09", "id": "ChestA"}, "to": {"map": "OMO_09", "id": 0},        "reqs": []}, #* ChestA (Dictionary) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemH"},  "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemH (StarPiece)
+    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemH"},  "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemH (StarPiece)
     {"from": {"map": "OMO_09", "id": "ItemH"},  "to": {"map": "OMO_09", "id": 0},        "reqs": []}, #* ItemH (StarPiece) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemO"},  "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemO (MysteryNote)
+    {"from": {"map": "OMO_09", "id": 0},        "to": {"map": "OMO_09", "id": "ItemO"},  "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemO (MysteryNote)
     {"from": {"map": "OMO_09", "id": "ItemO"},  "to": {"map": "OMO_09", "id": 0},        "reqs": []}, #* ItemO (MysteryNote) -> GRN Treadmills/Slot Machine Exit West
     # Treadmill Coins
     {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemB"}, "reqs": []}, #* GRN Treadmills/Slot Machine Exit West -> ItemB (Coin)
@@ -191,17 +188,17 @@ edges_omo = [
     {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemG"}, "reqs": []}, #* GRN Treadmills/Slot Machine Exit West -> ItemG (Coin)
     {"from": {"map": "OMO_09", "id": "ItemG"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemG (Coin) -> GRN Treadmills/Slot Machine Exit West
     # Starpiece Coins
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemI"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemI (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemI"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemI (Coin)
     {"from": {"map": "OMO_09", "id": "ItemI"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemI (Coin) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemJ"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemJ (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemJ"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemJ (Coin)
     {"from": {"map": "OMO_09", "id": "ItemJ"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemJ (Coin) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemK"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemK (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemK"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemK (Coin)
     {"from": {"map": "OMO_09", "id": "ItemK"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemK (Coin) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemL"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemL (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemL"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemL (Coin)
     {"from": {"map": "OMO_09", "id": "ItemL"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemL (Coin) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemM"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemM (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemM"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemM (Coin)
     {"from": {"map": "OMO_09", "id": "ItemM"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemM (Coin) -> GRN Treadmills/Slot Machine Exit West
-    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemN"}, "reqs": [require(partner="Bow")]}, #* GRN Treadmills/Slot Machine Exit West -> ItemN (Coin)
+    {"from": {"map": "OMO_09", "id": 0},       "to": {"map": "OMO_09", "id": "ItemN"}, "reqs": [["Bow"]]}, #* GRN Treadmills/Slot Machine Exit West -> ItemN (Coin)
     {"from": {"map": "OMO_09", "id": "ItemN"}, "to": {"map": "OMO_09", "id": 0},       "reqs": []}, #* ItemN (Coin) -> GRN Treadmills/Slot Machine Exit West
 
     # OMO_10 RED Station
@@ -217,9 +214,9 @@ edges_omo = [
     {"from": {"map": "OMO_10", "id": 0}, "to": {"map": "OMO_10", "id": 3}, "reqs": []}, #? RED Station Exit West -> RED Station Ride Train East
     {"from": {"map": "OMO_10", "id": 3}, "to": {"map": "OMO_10", "id": 0}, "reqs": []}, #? RED Station Ride Train East -> RED Station Exit West
     
-    {"from": {"map": "OMO_10", "id": 0},               "to": {"map": "OMO_10", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* RED Station Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "OMO_10", "id": 0},               "to": {"map": "OMO_10", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* RED Station Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "OMO_10", "id": "HiddenPanel"},   "to": {"map": "OMO_10", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> RED Station Exit West
-    {"from": {"map": "OMO_10", "id": 0},               "to": {"map": "OMO_10", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* RED Station Exit West -> HiddenYBlockA (SuperShroom)
+    {"from": {"map": "OMO_10", "id": 0},               "to": {"map": "OMO_10", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* RED Station Exit West -> HiddenYBlockA (SuperShroom)
     {"from": {"map": "OMO_10", "id": "HiddenYBlockA"}, "to": {"map": "OMO_10", "id": 0},               "reqs": []}, #* HiddenYBlockA (SuperShroom) -> RED Station Exit West
 
     # OMO_11 RED Moving Platforms
@@ -229,21 +226,21 @@ edges_omo = [
     {"from": {"map": "OMO_11", "id": 0}, "to": {"map": "OMO_11", "id": 1}, "reqs": []}, #? RED Moving Platforms Exit West -> RED Moving Platforms Exit East
     {"from": {"map": "OMO_11", "id": 1}, "to": {"map": "OMO_11", "id": 0}, "reqs": []}, #? RED Moving Platforms Exit East -> RED Moving Platforms Exit West
     
-    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* RED Moving Platforms Exit West -> HiddenYBlockA (VoltShroom)
+    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* RED Moving Platforms Exit West -> HiddenYBlockA (VoltShroom)
     {"from": {"map": "OMO_11", "id": "HiddenYBlockA"}, "to": {"map": "OMO_11", "id": 0},               "reqs": []}, #* HiddenYBlockA (VoltShroom) -> RED Moving Platforms Exit West
-    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* RED Moving Platforms Exit West -> HiddenYBlockB (SnowmanDoll)
+    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* RED Moving Platforms Exit West -> HiddenYBlockB (SnowmanDoll)
     {"from": {"map": "OMO_11", "id": "HiddenYBlockB"}, "to": {"map": "OMO_11", "id": 0},               "reqs": []}, #* HiddenYBlockB (SnowmanDoll) -> RED Moving Platforms Exit West
     {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "YBlockA"},       "reqs": []}, #* RED Moving Platforms Exit West -> YBlockA (Coin)
     {"from": {"map": "OMO_11", "id": "YBlockA"},       "to": {"map": "OMO_11", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> RED Moving Platforms Exit West
     {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "YBlockB"},       "reqs": []}, #* RED Moving Platforms Exit West -> YBlockB (Coin)
     {"from": {"map": "OMO_11", "id": "YBlockB"},       "to": {"map": "OMO_11", "id": 0},               "reqs": []}, #* YBlockB (Coin) -> RED Moving Platforms Exit West
-    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenRBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* RED Moving Platforms Exit West -> HiddenRBlockA (DeepFocus2)
+    {"from": {"map": "OMO_11", "id": 0},               "to": {"map": "OMO_11", "id": "HiddenRBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* RED Moving Platforms Exit West -> HiddenRBlockA (DeepFocus2)
     {"from": {"map": "OMO_11", "id": "HiddenRBlockA"}, "to": {"map": "OMO_11", "id": 0},               "reqs": []}, #* HiddenRBlockA (DeepFocus2) -> RED Moving Platforms Exit West
 
     # OMO_12 RED Lantern Ghost
     {"from": {"map": "OMO_12", "id": 0}, "to": {"map": "OMO_11", "id": 0}, "reqs": []}, # RED Lantern Ghost Exit East -> RED Moving Platforms Exit West
 
-    {"from": {"map": "OMO_12", "id": 0},         "to": {"map": "OMO_12", "id": "Partner"}, "reqs": [require(hammer=1,partner=["Kooper","Bombette"])]}, #* RED Lantern Ghost Exit East -> Partner (Watt)
+    {"from": {"map": "OMO_12", "id": 0},         "to": {"map": "OMO_12", "id": "Partner"}, "reqs": [["Hammer","Kooper","Bombette"]]}, #* RED Lantern Ghost Exit East -> Partner (Watt)
     {"from": {"map": "OMO_12", "id": "Partner"}, "to": {"map": "OMO_12", "id": 0},         "reqs": []}, #* Partner (Watt) -> RED Lantern Ghost Exit East
 
     # OMO_13 BLU Anti-Guy Hall
@@ -253,18 +250,18 @@ edges_omo = [
     {"from": {"map": "OMO_13", "id": 0}, "to": {"map": "OMO_13", "id": 1}, "reqs": []}, #? BLU Anti-Guy Hall Exit West -> BLU Anti-Guy Hall Exit East
     {"from": {"map": "OMO_13", "id": 1}, "to": {"map": "OMO_13", "id": 0}, "reqs": []}, #? BLU Anti-Guy Hall Exit East -> BLU Anti-Guy Hall Exit West
     
-    {"from": {"map": "OMO_13", "id": 0},               "to": {"map": "OMO_13", "id": "ChestA"},        "reqs": [require(flag="RF_CanVisitTayceT"),require(item="Lemon"),require(item="Cookbook"),require(item="CakeMix")]}, #* BLU Anti-Guy Hall Exit West -> ChestA (PowerPlusB)
+    {"from": {"map": "OMO_13", "id": 0},               "to": {"map": "OMO_13", "id": "ChestA"},        "reqs": [["RF_CanVisitTayceT"],["Lemon"],["Cookbook"],["CakeMix"]]}, #* BLU Anti-Guy Hall Exit West -> ChestA (PowerPlusB)
     {"from": {"map": "OMO_13", "id": "ChestA"},        "to": {"map": "OMO_13", "id": 0},               "reqs": []}, #* ChestA (PowerPlusB) -> BLU Anti-Guy Hall Exit West
     {"from": {"map": "OMO_13", "id": 0},               "to": {"map": "OMO_13", "id": "YBlockA"},       "reqs": []}, #* BLU Anti-Guy Hall Exit West -> YBlockA (Coin)
     {"from": {"map": "OMO_13", "id": "YBlockA"},       "to": {"map": "OMO_13", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> BLU Anti-Guy Hall Exit West
-    {"from": {"map": "OMO_13", "id": 0},               "to": {"map": "OMO_13", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* BLU Anti-Guy Hall Exit West -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "OMO_13", "id": 0},               "to": {"map": "OMO_13", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* BLU Anti-Guy Hall Exit West -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "OMO_13", "id": "HiddenYBlockA"}, "to": {"map": "OMO_13", "id": 0},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> BLU Anti-Guy Hall Exit West
 
     # OMO_14 RED Boss Antechamber
     {"from": {"map": "OMO_14", "id": 0}, "to": {"map": "OMO_02", "id": 1}, "reqs": []}, # RED Boss Antechamber Exit West -> RED Boss Barricade Exit East
     {"from": {"map": "OMO_14", "id": 1}, "to": {"map": "OMO_15", "id": 0}, "reqs": []}, # RED Boss Antechamber Exit East -> RED General Guy Room Exit West
     
-    {"from": {"map": "OMO_14", "id": 0}, "to": {"map": "OMO_14", "id": 1}, "reqs": [require(partner="Watt")]}, #? RED Boss Antechamber Exit West -> RED Boss Antechamber Exit East
+    {"from": {"map": "OMO_14", "id": 0}, "to": {"map": "OMO_14", "id": 1}, "reqs": [["Watt"]]}, #? RED Boss Antechamber Exit West -> RED Boss Antechamber Exit East
     {"from": {"map": "OMO_14", "id": 1}, "to": {"map": "OMO_14", "id": 0}, "reqs": []}, #? RED Boss Antechamber Exit East -> RED Boss Antechamber Exit West
 
     # OMO_15 RED General Guy Room

--- a/maps/graph_edges/edges_osr.py
+++ b/maps/graph_edges/edges_osr.py
@@ -1,6 +1,4 @@
 """This file represents all edges of the world graph that have origin-nodes in the OSR (Peach's Castle Grounds) area."""
-from rando_modules.simulate import require
-
 edges_osr = [
     # OSR_01 Ruined Castle Grounds
     {"from": {"map": "OSR_01", "id": 0}, "to": {"map": "MAC_01",  "id": 2}, "reqs": []}, # Ruined Castle Grounds Exit South -> Plaza District Exit North
@@ -16,6 +14,6 @@ edges_osr = [
     {"from": {"map": "OSR_02", "id": 0}, "to": {"map": "OSR_02", "id": 1}, "reqs": []}, #? Hijacked Castle Entrance Door West -> Hijacked Castle Entrance Door North
     {"from": {"map": "OSR_02", "id": 1}, "to": {"map": "OSR_02", "id": 0}, "reqs": []}, #? Hijacked Castle Entrance Door North -> Hijacked Castle Entrance Door West
     
-    {"from": {"map": "OSR_02", "id": 0},               "to": {"map": "OSR_02", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Hijacked Castle Entrance Door West -> HiddenYBlockA (UltraShroom)
+    {"from": {"map": "OSR_02", "id": 0},               "to": {"map": "OSR_02", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Hijacked Castle Entrance Door West -> HiddenYBlockA (UltraShroom)
     {"from": {"map": "OSR_02", "id": "HiddenYBlockA"}, "to": {"map": "OSR_02", "id": 0},               "reqs": []}, #* HiddenYBlockA (UltraShroom) -> Hijacked Castle Entrance Door West
 ]

--- a/maps/graph_edges/edges_pra.py
+++ b/maps/graph_edges/edges_pra.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the PRA (Crystal Palace) area."""
 edges_pra = [
     # PRA_01 Entrance
@@ -16,10 +14,10 @@ edges_pra = [
     # PRA_02 Entry Hall
     {"from": {"map": "PRA_02", "id": 0}, "to": {"map": "PRA_01", "id": 1}, "reqs": []}, # Entry Hall Entrance Door -> Entrance Front Door
     {"from": {"map": "PRA_02", "id": 1}, "to": {"map": "PRA_03", "id": 0}, "reqs": []}, # Entry Hall Hallway Door -> Save Room Door West
-    {"from": {"map": "PRA_02", "id": 2}, "to": {"map": "PRA_13", "id": 0}, "reqs": [require(item="BlueKey"), require(boots=2)]}, # Entry Hall Blue/Red Door -> Blue Mirror Hall 1 Door West
-    {"from": {"map": "PRA_02", "id": 2}, "to": {"map": "PRA_16", "id": 0}, "reqs": [require(item="RedKey")]}, # Entry Hall Blue/Red Door -> Red Mirror Hall Door West
-    {"from": {"map": "PRA_02", "id": 3}, "to": {"map": "PRA_13", "id": 3}, "reqs": [require(item="BlueKey"), require(boots=2)]}, # Entry Hall Blue/Red Door (Mirror Side) -> Blue Mirror Hall 1 Door West (Mirror Side)
-    {"from": {"map": "PRA_02", "id": 3}, "to": {"map": "PRA_16", "id": 3}, "reqs": [require(item="RedKey")]}, # Entry Hall Blue/Red Door (Mirror Side) -> Red Mirror Hall Door West (Mirror Side)
+    {"from": {"map": "PRA_02", "id": 2}, "to": {"map": "PRA_13", "id": 0}, "reqs": [["BlueKey"],["SuperBoots"]]}, # Entry Hall Blue/Red Door -> Blue Mirror Hall 1 Door West
+    {"from": {"map": "PRA_02", "id": 2}, "to": {"map": "PRA_16", "id": 0}, "reqs": [["RedKey"]]}, # Entry Hall Blue/Red Door -> Red Mirror Hall Door West
+    {"from": {"map": "PRA_02", "id": 3}, "to": {"map": "PRA_13", "id": 3}, "reqs": [["BlueKey"],["SuperBoots"]]}, # Entry Hall Blue/Red Door (Mirror Side) -> Blue Mirror Hall 1 Door West (Mirror Side)
+    {"from": {"map": "PRA_02", "id": 3}, "to": {"map": "PRA_16", "id": 3}, "reqs": [["RedKey"]]}, # Entry Hall Blue/Red Door (Mirror Side) -> Red Mirror Hall Door West (Mirror Side)
     {"from": {"map": "PRA_02", "id": 4}, "to": {"map": "PRA_04", "id": 0}, "reqs": []}, # Entry Hall Hallway Door (Mirror Side) -> Reflected Save Room Door West
     {"from": {"map": "PRA_02", "id": 5}, "to": {"map": "PRA_01", "id": 2}, "reqs": []}, # Entry Hall Entrance Door (Mirror Side) -> Entrance Front Door (Mirror Side)
     
@@ -39,7 +37,7 @@ edges_pra = [
     
     {"from": {"map": "PRA_03", "id": 0}, "to": {"map": "PRA_03", "id": 1}, "reqs": []}, #? Save Room Door West -> Save Room Door East
     {"from": {"map": "PRA_03", "id": 1}, "to": {"map": "PRA_03", "id": 0}, "reqs": []}, #? Save Room Door East -> Save Room Door West
-    {"from": {"map": "PRA_03", "id": 0}, "to": {"map": "PRA_03", "id": 2}, "reqs": [require(flag="GF_PRA04_BoardedFloor")]}, #? Save Room Door West -> Save Room Basement Door
+    {"from": {"map": "PRA_03", "id": 0}, "to": {"map": "PRA_03", "id": 2}, "reqs": [["GF_PRA04_BoardedFloor"]]}, #? Save Room Door West -> Save Room Basement Door
     {"from": {"map": "PRA_03", "id": 2}, "to": {"map": "PRA_03", "id": 0}, "reqs": []}, #? Save Room Basement Door -> Save Room Door West
 
     # PRA_04 Reflected Save Room
@@ -49,7 +47,7 @@ edges_pra = [
     
     {"from": {"map": "PRA_04", "id": 0}, "to": {"map": "PRA_04", "id": 1}, "reqs": []}, #? Reflected Save Room Door West -> Reflected Save Room Door East
     {"from": {"map": "PRA_04", "id": 1}, "to": {"map": "PRA_04", "id": 0}, "reqs": []}, #? Reflected Save Room Door East -> Reflected Save Room Door West
-    {"from": {"map": "PRA_04", "id": 0}, "to": {"map": "PRA_04", "id": 2}, "reqs": [require(boots=2)], "pseudoitems": ["GF_PRA04_BoardedFloor"]}, #? Reflected Save Room Door West -> Reflected Save Room Basement Door
+    {"from": {"map": "PRA_04", "id": 0}, "to": {"map": "PRA_04", "id": 2}, "reqs": [["SuperBoots"]], "pseudoitems": ["GF_PRA04_BoardedFloor"]}, #? Reflected Save Room Door West -> Reflected Save Room Basement Door
     {"from": {"map": "PRA_04", "id": 2}, "to": {"map": "PRA_04", "id": 0}, "reqs": []}, #? Reflected Save Room Basement Door -> Reflected Save Room Door West
     
     {"from": {"map": "PRA_04", "id": 0},         "to": {"map": "PRA_04", "id": "YBlockA"}, "reqs": []}, #* Reflected Save Room Door West -> YBlockA (SuperShroom)
@@ -71,7 +69,7 @@ edges_pra = [
     {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_03", "id": 2}, "reqs": []}, # Red Key Hall Door West -> Save Room Basement Door
     {"from": {"map": "PRA_09", "id": 1}, "to": {"map": "PRA_11", "id": 0}, "reqs": []}, # Red Key Hall Bombable Wall -> Red Key Room Bombable Wall
     
-    {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_09", "id": 1}, "reqs": [require(partner="Bombette"),require(hammer=1)]}, #? Red Key Hall Door West -> Red Key Hall Bombable Wall
+    {"from": {"map": "PRA_09", "id": 0}, "to": {"map": "PRA_09", "id": 1}, "reqs": [["Bombette"],["Hammer"]]}, #? Red Key Hall Door West -> Red Key Hall Bombable Wall
     {"from": {"map": "PRA_09", "id": 1}, "to": {"map": "PRA_09", "id": 0}, "reqs": []}, #? Red Key Hall Bombable Wall -> Red Key Hall Door West
 
     # PRA_10 P-Down, D-Up Hall
@@ -99,17 +97,17 @@ edges_pra = [
     {"from": {"map": "PRA_13", "id": 2}, "to": {"map": "PRA_14", "id": 1}, "reqs": []}, # Blue Mirror Hall 1 Bombable Wall (Mirror Side) -> Blue Mirror Hall 2 Bombable Wall (Mirror Side)
     {"from": {"map": "PRA_13", "id": 3}, "to": {"map": "PRA_02", "id": 3}, "reqs": []}, # Blue Mirror Hall 1 Door West (Mirror Side) -> Entry Hall Blue/Red Door (Mirror Side)
     
-    {"from": {"map": "PRA_13", "id": 0}, "to": {"map": "PRA_13", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Blue Mirror Hall 1 Door West -> Blue Mirror Hall 1 Bombable Wall
+    {"from": {"map": "PRA_13", "id": 0}, "to": {"map": "PRA_13", "id": 1}, "reqs": [["Bombette"]]}, #? Blue Mirror Hall 1 Door West -> Blue Mirror Hall 1 Bombable Wall
     {"from": {"map": "PRA_13", "id": 1}, "to": {"map": "PRA_13", "id": 0}, "reqs": []}, #? Blue Mirror Hall 1 Bombable Wall -> Blue Mirror Hall 1 Door West
-    {"from": {"map": "PRA_13", "id": 2}, "to": {"map": "PRA_13", "id": 3}, "reqs": [require(partner="Bombette")]}, #? Blue Mirror Hall 1 Bombable Wall (Mirror Side) -> Blue Mirror Hall 1 Door West (Mirror Side)
+    {"from": {"map": "PRA_13", "id": 2}, "to": {"map": "PRA_13", "id": 3}, "reqs": [["Bombette"]]}, #? Blue Mirror Hall 1 Bombable Wall (Mirror Side) -> Blue Mirror Hall 1 Door West (Mirror Side)
     {"from": {"map": "PRA_13", "id": 3}, "to": {"map": "PRA_13", "id": 2}, "reqs": []}, #? Blue Mirror Hall 1 Door West (Mirror Side) -> Blue Mirror Hall 1 Bombable Wall (Mirror Side)
 
     # PRA_14 Blue Mirror Hall 2
     {"from": {"map": "PRA_14", "id": 0}, "to": {"map": "PRA_13", "id": 1}, "reqs": []}, # Blue Mirror Hall 2 Bombable Wall -> Blue Mirror Hall 1 Bombable Wall
     {"from": {"map": "PRA_14", "id": 1}, "to": {"map": "PRA_13", "id": 2}, "reqs": []}, # Blue Mirror Hall 2 Bombable Wall (Mirror Side) -> Blue Mirror Hall 1 Bombable Wall (Mirror Side)
     
-    {"from": {"map": "PRA_14", "id": 0}, "to": {"map": "PRA_14", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Blue Mirror Hall 2 Bombable Wall -> Blue Mirror Hall 2 Bombable Wall (Mirror Side)
-    {"from": {"map": "PRA_14", "id": 1}, "to": {"map": "PRA_14", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Blue Mirror Hall 2 Bombable Wall (Mirror Side) -> Blue Mirror Hall 2 Bombable Wall
+    {"from": {"map": "PRA_14", "id": 0}, "to": {"map": "PRA_14", "id": 1}, "reqs": [["Bombette"]]}, #? Blue Mirror Hall 2 Bombable Wall -> Blue Mirror Hall 2 Bombable Wall (Mirror Side)
+    {"from": {"map": "PRA_14", "id": 1}, "to": {"map": "PRA_14", "id": 0}, "reqs": [["Bombette"]]}, #? Blue Mirror Hall 2 Bombable Wall (Mirror Side) -> Blue Mirror Hall 2 Bombable Wall
 
     # PRA_15 Star Piece Cave
     {"from": {"map": "PRA_15", "id": 0}, "to": {"map": "PRA_01", "id": 3}, "reqs": []}, # Star Piece Cave Cave Entrance -> Entrance Cave Entrance
@@ -135,8 +133,8 @@ edges_pra = [
     {"from": {"map": "PRA_18", "id": 1}, "to": {"map": "PRA_33", "id": 1}, "reqs": []}, # Bridge Mirror Hall Door East (Mirror Side) -> Turnstyle Room Door West
     {"from": {"map": "PRA_18", "id": 2}, "to": {"map": "PRA_16", "id": 2}, "reqs": []}, # Bridge Mirror Hall Door West (Mirror Side) -> Red Mirror Hall Door East (Mirror Side)
     
-    {"from": {"map": "PRA_18", "id": 1}, "to": {"map": "PRA_18", "id": 2}, "reqs": [require(flag="MF_PRA_18_DefeatedClubbas")]}, #? Bridge Mirror Hall Door East (Mirror Side) -> Bridge Mirror Hall Door West (Mirror Side)
-    {"from": {"map": "PRA_18", "id": 2}, "to": {"map": "PRA_18", "id": 1}, "reqs": [require(flag="MF_PRA_18_DefeatedClubbas")]}, #? Bridge Mirror Hall Door West (Mirror Side) -> Bridge Mirror Hall Door East (Mirror Side)
+    {"from": {"map": "PRA_18", "id": 1}, "to": {"map": "PRA_18", "id": 2}, "reqs": [["MF_PRA_18_DefeatedClubbas"]]}, #? Bridge Mirror Hall Door East (Mirror Side) -> Bridge Mirror Hall Door West (Mirror Side)
+    {"from": {"map": "PRA_18", "id": 2}, "to": {"map": "PRA_18", "id": 1}, "reqs": [["MF_PRA_18_DefeatedClubbas"]]}, #? Bridge Mirror Hall Door West (Mirror Side) -> Bridge Mirror Hall Door East (Mirror Side)
     
     {"from": {"map": "PRA_18", "id": 0}, "to": {"map": "PRA_18", "id": 0}, "reqs": [], "pseudoitems": ["MF_PRA_18_DefeatedClubbas"]}, #+ Bridge Mirror Hall Door West
 
@@ -144,7 +142,7 @@ edges_pra = [
     {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_35", "id": 1}, "reqs": []}, # Reflection Mimic Room Door West -> Triple Dip Room Door East
     {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_20", "id": 0}, "reqs": []}, # Reflection Mimic Room Bombable Wall -> Mirrored Door Room Bombable Wall
     
-    {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_19", "id": 1}, "reqs": [require(partner="Kooper"),require(hammer=1)]}, #? Reflection Mimic Room Door West -> Reflection Mimic Room Bombable Wall
+    {"from": {"map": "PRA_19", "id": 0}, "to": {"map": "PRA_19", "id": 1}, "reqs": [["Kooper"],["Hammer"]]}, #? Reflection Mimic Room Door West -> Reflection Mimic Room Bombable Wall
     {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_19", "id": 0}, "reqs": []}, #? Reflection Mimic Room Bombable Wall -> Reflection Mimic Room Door West
 
     # PRA_20 Mirrored Door Room
@@ -165,12 +163,12 @@ edges_pra = [
     {"from": {"map": "PRA_21", "id": 0}, "to": {"map": "PRA_20", "id": 1}, "reqs": []}, # Huge Statue Room Door West -> Mirrored Door Room Hallway Door
     {"from": {"map": "PRA_21", "id": 1}, "to": {"map": "PRA_36", "id": 0}, "reqs": []}, # Huge Statue Room Basement Door -> Palace Key Hall Door West
     
-    {"from": {"map": "PRA_21", "id": 0}, "to": {"map": "PRA_21", "id": 1}, "reqs": [require(flag="MF_PRA_22_FoundHiddenRoomUnderStatue")]}, #? Huge Statue Room Door West -> Huge Statue Room Basement Door
+    {"from": {"map": "PRA_21", "id": 0}, "to": {"map": "PRA_21", "id": 1}, "reqs": [["MF_PRA_22_FoundHiddenRoomUnderStatue"]]}, #? Huge Statue Room Door West -> Huge Statue Room Basement Door
     {"from": {"map": "PRA_21", "id": 1}, "to": {"map": "PRA_21", "id": 0}, "reqs": []}, #? Huge Statue Room Basement Door -> Huge Statue Room Door West
     
-    {"from": {"map": "PRA_21", "id": 0},             "to": {"map": "PRA_21", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Huge Statue Room Door West -> HiddenPanel (StarPiece)
+    {"from": {"map": "PRA_21", "id": 0},             "to": {"map": "PRA_21", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Huge Statue Room Door West -> HiddenPanel (StarPiece)
     {"from": {"map": "PRA_21", "id": "HiddenPanel"}, "to": {"map": "PRA_21", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Huge Statue Room Door West
-    {"from": {"map": "PRA_21", "id": 0},             "to": {"map": "PRA_21", "id": "YBlockA"},     "reqs": [require(boots=3)]}, #* Huge Statue Room Door West -> YBlockA (MapleSyrup)
+    {"from": {"map": "PRA_21", "id": 0},             "to": {"map": "PRA_21", "id": "YBlockA"},     "reqs": [["UltraBoots"]]}, #* Huge Statue Room Door West -> YBlockA (MapleSyrup)
     {"from": {"map": "PRA_21", "id": "YBlockA"},     "to": {"map": "PRA_21", "id": 0},             "reqs": []}, #* YBlockA (MapleSyrup) -> Huge Statue Room Door West
 
     # PRA_22 Small Statue Room
@@ -182,9 +180,9 @@ edges_pra = [
     
     {"from": {"map": "PRA_22", "id": 0}, "to": {"map": "PRA_22", "id": 1}, "reqs": [], "pseudoitems": ["MF_PRA_22_FoundHiddenRoomUnderStatue"]}, #+ Small Statue Room Door West
     
-    {"from": {"map": "PRA_22", "id": 0},               "to": {"map": "PRA_22", "id": "HiddenPanel"},   "reqs": [can_flip_panels]}, #* Small Statue Room Door West -> HiddenPanel (StarPiece)
+    {"from": {"map": "PRA_22", "id": 0},               "to": {"map": "PRA_22", "id": "HiddenPanel"},   "reqs": [["can_flip_panels"]]}, #* Small Statue Room Door West -> HiddenPanel (StarPiece)
     {"from": {"map": "PRA_22", "id": "HiddenPanel"},   "to": {"map": "PRA_22", "id": 0},               "reqs": []}, #* HiddenPanel (StarPiece) -> Small Statue Room Door West
-    {"from": {"map": "PRA_22", "id": 0},               "to": {"map": "PRA_22", "id": "HiddenYBlockA"}, "reqs": [require(boots=3),require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Small Statue Room Door West -> HiddenYBlockA (JamminJelly)
+    {"from": {"map": "PRA_22", "id": 0},               "to": {"map": "PRA_22", "id": "HiddenYBlockA"}, "reqs": [["UltraBoots"],["can_see_hidden_blocks"]]}, #* Small Statue Room Door West -> HiddenYBlockA (JamminJelly)
     {"from": {"map": "PRA_22", "id": "HiddenYBlockA"}, "to": {"map": "PRA_22", "id": 0},               "reqs": []}, #* HiddenYBlockA (JamminJelly) -> Small Statue Room Door West
 
     # PRA_27 Palace Key Room
@@ -205,7 +203,7 @@ edges_pra = [
     {"from": {"map": "PRA_29", "id": 2}, "to": {"map": "PRA_34", "id": 3}, "reqs": []}, # Hidden Bridge Room Door East (Mirror Side) -> Mirror Hole Room Door West (Mirror Side)
     {"from": {"map": "PRA_29", "id": 3}, "to": {"map": "PRA_20", "id": 3}, "reqs": []}, # Hidden Bridge Room Door West (Mirror Side) -> Mirrored Door Room Door East (Mirror Side)
     
-    {"from": {"map": "PRA_29", "id": 0}, "to": {"map": "PRA_29", "id": 1}, "reqs": [require(partner="Kooper")]}, #? Hidden Bridge Room Door West -> Hidden Bridge Room Door East
+    {"from": {"map": "PRA_29", "id": 0}, "to": {"map": "PRA_29", "id": 1}, "reqs": [["Kooper"]]}, #? Hidden Bridge Room Door West -> Hidden Bridge Room Door East
     {"from": {"map": "PRA_29", "id": 1}, "to": {"map": "PRA_29", "id": 0}, "reqs": []}, #? Hidden Bridge Room Door East -> Hidden Bridge Room Door West
     {"from": {"map": "PRA_29", "id": 2}, "to": {"map": "PRA_29", "id": 3}, "reqs": []}, #? Hidden Bridge Room Door East (Mirror Side) -> Hidden Bridge Room Door West (Mirror Side)
     {"from": {"map": "PRA_29", "id": 3}, "to": {"map": "PRA_29", "id": 2}, "reqs": []}, #? Hidden Bridge Room Door West (Mirror Side) -> Hidden Bridge Room Door East (Mirror Side)
@@ -228,9 +226,9 @@ edges_pra = [
     {"from": {"map": "PRA_33", "id": 1}, "to": {"map": "PRA_18", "id": 1}, "reqs": []}, # Turnstyle Room Door West -> Bridge Mirror Hall Door East (Mirror Side)
     {"from": {"map": "PRA_33", "id": 2}, "to": {"map": "PRA_35", "id": 2}, "reqs": []}, # Turnstyle Room Bombable Wall (Mirror Side) -> Triple Dip Room Bombable Wall (Mirror Side)
     
-    {"from": {"map": "PRA_33", "id": 0}, "to": {"map": "PRA_33", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Turnstyle Room Door East -> Turnstyle Room Door West
-    {"from": {"map": "PRA_33", "id": 1}, "to": {"map": "PRA_33", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Turnstyle Room Door West -> Turnstyle Room Door East
-    {"from": {"map": "PRA_33", "id": 1}, "to": {"map": "PRA_33", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Turnstyle Room Door West -> Turnstyle Room Bombable Wall (Mirror Side)
+    {"from": {"map": "PRA_33", "id": 0}, "to": {"map": "PRA_33", "id": 1}, "reqs": [["Bombette"]]}, #? Turnstyle Room Door East -> Turnstyle Room Door West
+    {"from": {"map": "PRA_33", "id": 1}, "to": {"map": "PRA_33", "id": 0}, "reqs": [["Bombette"]]}, #? Turnstyle Room Door West -> Turnstyle Room Door East
+    {"from": {"map": "PRA_33", "id": 1}, "to": {"map": "PRA_33", "id": 2}, "reqs": [["Bombette"]]}, #? Turnstyle Room Door West -> Turnstyle Room Bombable Wall (Mirror Side)
     {"from": {"map": "PRA_33", "id": 2}, "to": {"map": "PRA_33", "id": 1}, "reqs": []}, #? Turnstyle Room Bombable Wall (Mirror Side) -> Turnstyle Room Door West
 
     # PRA_34 Mirror Hole Room
@@ -239,9 +237,9 @@ edges_pra = [
     {"from": {"map": "PRA_34", "id": 2}, "to": {"map": "PRA_31", "id": 2}, "reqs": []}, # Mirror Hole Room Door East (Mirror Side) -> Dino Puzzle Room Door West (Mirror Side)
     {"from": {"map": "PRA_34", "id": 3}, "to": {"map": "PRA_29", "id": 2}, "reqs": []}, # Mirror Hole Room Door West (Mirror Side) -> Hidden Bridge Room Door East (Mirror Side)
     
-    {"from": {"map": "PRA_34", "id": 0}, "to": {"map": "PRA_34", "id": 1}, "reqs": [require(item="CrystalPalaceKey")]}, #? Mirror Hole Room Door West -> Mirror Hole Room Door East
+    {"from": {"map": "PRA_34", "id": 0}, "to": {"map": "PRA_34", "id": 1}, "reqs": [["CrystalPalaceKey"]]}, #? Mirror Hole Room Door West -> Mirror Hole Room Door East
     {"from": {"map": "PRA_34", "id": 1}, "to": {"map": "PRA_34", "id": 0}, "reqs": []}, #? Mirror Hole Room Door East -> Mirror Hole Room Door West
-    {"from": {"map": "PRA_34", "id": 0}, "to": {"map": "PRA_34", "id": 2}, "reqs": [require(item="CrystalPalaceKey")]}, #? Mirror Hole Room Door West -> Mirror Hole Room Door East (Mirror Side)
+    {"from": {"map": "PRA_34", "id": 0}, "to": {"map": "PRA_34", "id": 2}, "reqs": [["CrystalPalaceKey"]]}, #? Mirror Hole Room Door West -> Mirror Hole Room Door East (Mirror Side)
     {"from": {"map": "PRA_34", "id": 2}, "to": {"map": "PRA_34", "id": 0}, "reqs": []}, #? Mirror Hole Room Door East (Mirror Side) -> Mirror Hole Room Door West
     {"from": {"map": "PRA_34", "id": 0}, "to": {"map": "PRA_34", "id": 3}, "reqs": []}, #? Mirror Hole Room Door West -> Mirror Hole Room Door West (Mirror Side)
     {"from": {"map": "PRA_34", "id": 3}, "to": {"map": "PRA_34", "id": 0}, "reqs": []}, #? Mirror Hole Room Door West (Mirror Side) -> Mirror Hole Room Door West
@@ -255,7 +253,7 @@ edges_pra = [
     {"from": {"map": "PRA_35", "id": 1}, "to": {"map": "PRA_35", "id": 0}, "reqs": []}, #? Triple Dip Room Door East -> Triple Dip Room Door West
     
     {"from": {"map": "PRA_35", "id": 2},        "to": {"map": "PRA_35", "id": "ChestA"}, "reqs": []}, #* Triple Dip Room Bombable Wall (Mirror Side) -> ChestA (TripleDip)
-    {"from": {"map": "PRA_35", "id": "ChestA"}, "to": {"map": "PRA_35", "id": 2},        "reqs": [require(partner="Bombette")]}, #* ChestA (TripleDip) -> Triple Dip Room Bombable Wall (Mirror Side)
+    {"from": {"map": "PRA_35", "id": "ChestA"}, "to": {"map": "PRA_35", "id": 2},        "reqs": [["Bombette"]]}, #* ChestA (TripleDip) -> Triple Dip Room Bombable Wall (Mirror Side)
 
     # PRA_36 Palace Key Hall
     {"from": {"map": "PRA_36", "id": 0}, "to": {"map": "PRA_21", "id": 1}, "reqs": []}, # Palace Key Hall Door West -> Huge Statue Room Basement Door

--- a/maps/graph_edges/edges_sam.py
+++ b/maps/graph_edges/edges_sam.py
@@ -1,16 +1,14 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the SAM (Shiver Mountain) area."""
 edges_sam = [
     # SAM_01 Shiver City Mayor Area
     {"from": {"map": "SAM_01", "id": 0}, "to": {"map": "SAM_02", "id": 0}, "reqs": []}, # Shiver City Mayor Area Exit East -> Shiver City Center Exit West
 
     {"from": {"map": "SAM_01", "id": 0}, "to": {"map": "SAM_01", "id": 0}, "reqs": [], "pseudoitems": ["RF_Ch7_MurderMysteryStarted"]}, #+ Shiver City Mayor Area Exit East
-    {"from": {"map": "SAM_01", "id": 0}, "to": {"map": "SAM_01", "id": 0}, "reqs": [require(flag="RF_Ch7_SpokeWithHerringway")], "pseudoitems": ["RF_Ch7_MurderMysterySolved"]}, #+ Shiver City Mayor Area Exit East
+    {"from": {"map": "SAM_01", "id": 0}, "to": {"map": "SAM_01", "id": 0}, "reqs": [["RF_Ch7_SpokeWithHerringway"]], "pseudoitems": ["RF_Ch7_MurderMysterySolved"]}, #+ Shiver City Mayor Area Exit East
     
-    {"from": {"map": "SAM_01", "id": 0},             "to": {"map": "SAM_01", "id": "HiddenPanel"}, "reqs": [can_flip_panels, require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Mayor Area Exit East -> HiddenPanel (StarPiece)
+    {"from": {"map": "SAM_01", "id": 0},             "to": {"map": "SAM_01", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"],["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Mayor Area Exit East -> HiddenPanel (StarPiece)
     {"from": {"map": "SAM_01", "id": "HiddenPanel"}, "to": {"map": "SAM_01", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Shiver City Mayor Area Exit East
-    {"from": {"map": "SAM_01", "id": 0},             "to": {"map": "SAM_01", "id": "GiftA"},       "reqs": [require(flag="RF_Ch7_MurderMysterySolved"), require(flag="RF_Ch7_GotSnowmanScarf")]}, #* Shiver City Mayor Area Exit East -> GiftA (SnowmanBucket)
+    {"from": {"map": "SAM_01", "id": 0},             "to": {"map": "SAM_01", "id": "GiftA"},       "reqs": [["RF_Ch7_MurderMysterySolved"],["RF_Ch7_GotSnowmanScarf"]]}, #* Shiver City Mayor Area Exit East -> GiftA (SnowmanBucket)
     {"from": {"map": "SAM_01", "id": "GiftA"},       "to": {"map": "SAM_01", "id": 0},             "reqs": []}, #* GiftA (SnowmanBucket) -> Shiver City Mayor Area Exit East
     {"from": {"map": "SAM_01", "id": 0},             "to": {"map": "SAM_01", "id": "ChestA"},      "reqs": []}, #* Shiver City Mayor Area Exit East -> ChestA (AttackFXE)
     {"from": {"map": "SAM_01", "id": "ChestA"},      "to": {"map": "SAM_01", "id": 0},             "reqs": []}, #* ChestA (AttackFXE) -> Shiver City Mayor Area Exit East
@@ -36,27 +34,27 @@ edges_sam = [
     
     {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemA"},     "reqs": []}, #* Shiver City Center Exit West -> ItemA (IcedPotato)
     {"from": {"map": "SAM_02", "id": "ItemA"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemA (IcedPotato) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemB"},     "reqs": [require(flag="MF_SAM_04_UnlockedShiverMountain")]}, #* Shiver City Center Exit West -> ItemB (UltraShroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemB"},     "reqs": [["MF_SAM_04_UnlockedShiverMountain"]]}, #* Shiver City Center Exit West -> ItemB (UltraShroom)
     {"from": {"map": "SAM_02", "id": "ItemB"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemB (UltraShroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemC"},     "reqs": [require(flag="MF_SAM_04_UnlockedShiverMountain")]}, #* Shiver City Center Exit West -> ItemC (Mushroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemC"},     "reqs": [["MF_SAM_04_UnlockedShiverMountain"]]}, #* Shiver City Center Exit West -> ItemC (Mushroom)
     {"from": {"map": "SAM_02", "id": "ItemC"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemC (Mushroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemD"},     "reqs": [require(flag="MF_SAM_04_UnlockedShiverMountain")]}, #* Shiver City Center Exit West -> ItemD (Mushroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemD"},     "reqs": [["MF_SAM_04_UnlockedShiverMountain"]]}, #* Shiver City Center Exit West -> ItemD (Mushroom)
     {"from": {"map": "SAM_02", "id": "ItemD"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemD (Mushroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemE"},     "reqs": [require(flag="MF_SAM_04_UnlockedShiverMountain")]}, #* Shiver City Center Exit West -> ItemE (Mushroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemE"},     "reqs": [["MF_SAM_04_UnlockedShiverMountain"]]}, #* Shiver City Center Exit West -> ItemE (Mushroom)
     {"from": {"map": "SAM_02", "id": "ItemE"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemE (Mushroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemF"},     "reqs": [require(flag="MF_SAM_04_UnlockedShiverMountain")]}, #* Shiver City Center Exit West -> ItemF (Mushroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ItemF"},     "reqs": [["MF_SAM_04_UnlockedShiverMountain"]]}, #* Shiver City Center Exit West -> ItemF (Mushroom)
     {"from": {"map": "SAM_02", "id": "ItemF"},     "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ItemF (Mushroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemA"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemA (DizzyDial)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemA"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemA (DizzyDial)
     {"from": {"map": "SAM_02", "id": "ShopItemA"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemA (DizzyDial) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemB"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemB (ShootingStar)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemB"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemB (ShootingStar)
     {"from": {"map": "SAM_02", "id": "ShopItemB"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemB (ShootingStar) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemC"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemC (SnowmanDoll)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemC"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemC (SnowmanDoll)
     {"from": {"map": "SAM_02", "id": "ShopItemC"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemC (SnowmanDoll) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemD"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemD (MapleSyrup)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemD"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemD (MapleSyrup)
     {"from": {"map": "SAM_02", "id": "ShopItemD"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemD (MapleSyrup) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemE"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemE (LifeShroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemE"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemE (LifeShroom)
     {"from": {"map": "SAM_02", "id": "ShopItemE"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemE (LifeShroom) -> Shiver City Center Exit West
-    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemF"}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #* Shiver City Center Exit West -> ShopItemF (SuperShroom)
+    {"from": {"map": "SAM_02", "id": 0},           "to": {"map": "SAM_02", "id": "ShopItemF"}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #* Shiver City Center Exit West -> ShopItemF (SuperShroom)
     {"from": {"map": "SAM_02", "id": "ShopItemF"}, "to": {"map": "SAM_02", "id": 0},           "reqs": []}, #* ShopItemF (SuperShroom) -> Shiver City Center Exit West
 
     {"from": {"map": "SAM_02", "id": 0}, "to": {"map": "SAM_02", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_SAM_1",
@@ -82,12 +80,12 @@ edges_sam = [
     
     {"from": {"map": "SAM_04", "id": 0}, "to": {"map": "SAM_04", "id": 1}, "reqs": []}, #? Shiver Snowfield Exit West -> Shiver Snowfield Exit East
     {"from": {"map": "SAM_04", "id": 1}, "to": {"map": "SAM_04", "id": 0}, "reqs": []}, #? Shiver Snowfield Exit East -> Shiver Snowfield Exit West
-    {"from": {"map": "SAM_04", "id": 0}, "to": {"map": "SAM_04", "id": 2}, "reqs": [require(item="SnowmanBucket"), require(item="SnowmanScarf")], "pseudoitems": ["MF_SAM_04_UnlockedShiverMountain"]}, #? Shiver Snowfield Exit West -> Shiver Snowfield Mountain Entrance
+    {"from": {"map": "SAM_04", "id": 0}, "to": {"map": "SAM_04", "id": 2}, "reqs": [["SnowmanBucket"],["SnowmanScarf"]], "pseudoitems": ["MF_SAM_04_UnlockedShiverMountain"]}, #? Shiver Snowfield Exit West -> Shiver Snowfield Mountain Entrance
     {"from": {"map": "SAM_04", "id": 2}, "to": {"map": "SAM_04", "id": 0}, "reqs": []}, #? Shiver Snowfield Mountain Entrance -> Shiver Snowfield Exit West
     
-    {"from": {"map": "SAM_04", "id": 0},             "to": {"map": "SAM_04", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Shiver Snowfield Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "SAM_04", "id": 0},             "to": {"map": "SAM_04", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Shiver Snowfield Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "SAM_04", "id": "HiddenPanel"}, "to": {"map": "SAM_04", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Shiver Snowfield Exit West
-    {"from": {"map": "SAM_04", "id": 0},             "to": {"map": "SAM_04", "id": "Tree2_Drop1"}, "reqs": [require(hammer=1)]}, #* Shiver Snowfield Exit West -> Tree2_Drop1 (Letter05)
+    {"from": {"map": "SAM_04", "id": 0},             "to": {"map": "SAM_04", "id": "Tree2_Drop1"}, "reqs": [["Hammer"]]}, #* Shiver Snowfield Exit West -> Tree2_Drop1 (Letter05)
     {"from": {"map": "SAM_04", "id": "Tree2_Drop1"}, "to": {"map": "SAM_04", "id": 0},             "reqs": []}, #* Tree2_Drop1 (Letter05) -> Shiver Snowfield Exit West
     {"from": {"map": "SAM_04", "id": 0},             "to": {"map": "SAM_04", "id": "ItemA"},       "reqs": []}, #* Shiver Snowfield Exit West -> ItemA (RepelGel)
     {"from": {"map": "SAM_04", "id": "ItemA"},       "to": {"map": "SAM_04", "id": 0},             "reqs": []}, #* ItemA (RepelGel) -> Shiver Snowfield Exit West
@@ -101,7 +99,7 @@ edges_sam = [
     
     {"from": {"map": "SAM_05", "id": 0},               "to": {"map": "SAM_05", "id": "ItemA"},         "reqs": []}, #* Path to Starborn Valley Exit West -> ItemA (Letter06)
     {"from": {"map": "SAM_05", "id": "ItemA"},         "to": {"map": "SAM_05", "id": 0},               "reqs": []}, #* ItemA (Letter06) -> Path to Starborn Valley Exit West
-    {"from": {"map": "SAM_05", "id": 0},               "to": {"map": "SAM_05", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Path to Starborn Valley Exit West -> HiddenYBlockA (StopWatch)
+    {"from": {"map": "SAM_05", "id": 0},               "to": {"map": "SAM_05", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Path to Starborn Valley Exit West -> HiddenYBlockA (StopWatch)
     {"from": {"map": "SAM_05", "id": "HiddenYBlockA"}, "to": {"map": "SAM_05", "id": 0},               "reqs": []}, #* HiddenYBlockA (StopWatch) -> Path to Starborn Valley Exit West
 
     # SAM_06 Starborn Valley
@@ -114,21 +112,21 @@ edges_sam = [
     {"from": {"map": "SAM_07", "id": 0}, "to": {"map": "SAM_04", "id": 2}, "reqs": []}, # Shiver Mountain Passage Mountain Entrance -> Shiver Snowfield Mountain Entrance
     {"from": {"map": "SAM_07", "id": 1}, "to": {"map": "SAM_08", "id": 0}, "reqs": []}, # Shiver Mountain Passage Exit East -> Shiver Mountain Hills Exit West
     
-    {"from": {"map": "SAM_07", "id": 0}, "to": {"map": "SAM_07", "id": 1}, "reqs": [require(boots=2)]}, #? Shiver Mountain Passage Mountain Entrance -> Shiver Mountain Passage Exit East
-    {"from": {"map": "SAM_07", "id": 1}, "to": {"map": "SAM_07", "id": 0}, "reqs": [require(boots=2)]}, #? Shiver Mountain Passage Exit East -> Shiver Mountain Passage Mountain Entrance
+    {"from": {"map": "SAM_07", "id": 0}, "to": {"map": "SAM_07", "id": 1}, "reqs": [["SuperBoots"]]}, #? Shiver Mountain Passage Mountain Entrance -> Shiver Mountain Passage Exit East
+    {"from": {"map": "SAM_07", "id": 1}, "to": {"map": "SAM_07", "id": 0}, "reqs": [["SuperBoots"]]}, #? Shiver Mountain Passage Exit East -> Shiver Mountain Passage Mountain Entrance
     
-    {"from": {"map": "SAM_07", "id": 1},               "to": {"map": "SAM_07", "id": "HiddenYBlockA"}, "reqs": [require(boots=3)]}, #* Shiver Mountain Passage Exit East -> HiddenYBlockA (UltraShroom)
+    {"from": {"map": "SAM_07", "id": 1},               "to": {"map": "SAM_07", "id": "HiddenYBlockA"}, "reqs": [["UltraBoots"]]}, #* Shiver Mountain Passage Exit East -> HiddenYBlockA (UltraShroom)
     {"from": {"map": "SAM_07", "id": "HiddenYBlockA"}, "to": {"map": "SAM_07", "id": 1},               "reqs": []}, #* HiddenYBlockA (UltraShroom) -> Shiver Mountain Passage Exit East
 
     # SAM_08 Shiver Mountain Hills
     {"from": {"map": "SAM_08", "id": 0}, "to": {"map": "SAM_07", "id": 1}, "reqs": []}, # Shiver Mountain Hills Exit West -> Shiver Mountain Passage Exit East
     {"from": {"map": "SAM_08", "id": 1}, "to": {"map": "SAM_09", "id": 0}, "reqs": []}, # Shiver Mountain Hills Exit East -> Shiver Mountain Tunnel Exit West
     
-    {"from": {"map": "SAM_08", "id": 0}, "to": {"map": "SAM_08", "id": 1}, "reqs": [require(flag="RF_DefeatedFirstDuplighost")]}, #? Shiver Mountain Hills Exit West -> Shiver Mountain Hills Exit East
+    {"from": {"map": "SAM_08", "id": 0}, "to": {"map": "SAM_08", "id": 1}, "reqs": [["RF_DefeatedFirstDuplighost"]]}, #? Shiver Mountain Hills Exit West -> Shiver Mountain Hills Exit East
     {"from": {"map": "SAM_08", "id": 1}, "to": {"map": "SAM_08", "id": 0}, "reqs": []}, #? Shiver Mountain Hills Exit East -> Shiver Mountain Hills Exit West
     
-    {"from": {"map": "SAM_08", "id": 1}, "to": {"map": "SAM_08", "id": 1}, "reqs": [require(hammer=1)], "pseudoitems": ["RF_DefeatedFirstDuplighost"]}, #+ Shiver Mountain Hills Exit East
-    {"from": {"map": "SAM_08", "id": 0}, "to": {"map": "SAM_08", "id": 0}, "reqs": [require(partner="Kooper"), require(hammer=1)], "pseudoitems": ["RF_DefeatedFirstDuplighost"]}, #+ Shiver Mountain Hills Exit East
+    {"from": {"map": "SAM_08", "id": 1}, "to": {"map": "SAM_08", "id": 1}, "reqs": [["Hammer"]], "pseudoitems": ["RF_DefeatedFirstDuplighost"]}, #+ Shiver Mountain Hills Exit East
+    {"from": {"map": "SAM_08", "id": 0}, "to": {"map": "SAM_08", "id": 0}, "reqs": [["Kooper"],["Hammer"]], "pseudoitems": ["RF_DefeatedFirstDuplighost"]}, #+ Shiver Mountain Hills Exit East
 
     {"from": {"map": "SAM_08", "id": 0},       "to": {"map": "SAM_08", "id": "ItemA"}, "reqs": []}, #* Shiver Mountain Hills Exit West -> ItemA (Pebble)
     {"from": {"map": "SAM_08", "id": "ItemA"}, "to": {"map": "SAM_08", "id": 0},       "reqs": []}, #* ItemA (Pebble) -> Shiver Mountain Hills Exit West
@@ -152,26 +150,26 @@ edges_sam = [
     {"from": {"map": "SAM_10", "id": 1}, "to": {"map": "PRA_01", "id": 0}, "reqs": []}, # Shiver Mountain Peaks Exit East -> Entrance Exit West
     {"from": {"map": "SAM_10", "id": 2}, "to": {"map": "SAM_12", "id": 0}, "reqs": []}, # Shiver Mountain Peaks Bombable Wall -> Merlar's Sanctuary Bombable Wall
     
-    {"from": {"map": "SAM_10", "id": 0}, "to": {"map": "SAM_10", "id": 1}, "reqs": [require(item="StarStone")]}, #? Shiver Mountain Peaks Exit West -> Shiver Mountain Peaks Exit East
+    {"from": {"map": "SAM_10", "id": 0}, "to": {"map": "SAM_10", "id": 1}, "reqs": [["StarStone"]]}, #? Shiver Mountain Peaks Exit West -> Shiver Mountain Peaks Exit East
     {"from": {"map": "SAM_10", "id": 1}, "to": {"map": "SAM_10", "id": 0}, "reqs": []}, #? Shiver Mountain Peaks Exit East -> Shiver Mountain Peaks Exit West
-    {"from": {"map": "SAM_10", "id": 0}, "to": {"map": "SAM_10", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Shiver Mountain Peaks Exit West -> Shiver Mountain Peaks Bombable Wall
+    {"from": {"map": "SAM_10", "id": 0}, "to": {"map": "SAM_10", "id": 2}, "reqs": [["Bombette"]]}, #? Shiver Mountain Peaks Exit West -> Shiver Mountain Peaks Bombable Wall
     {"from": {"map": "SAM_10", "id": 2}, "to": {"map": "SAM_10", "id": 0}, "reqs": []}, #? Shiver Mountain Peaks Bombable Wall -> Shiver Mountain Peaks Exit West
     
-    {"from": {"map": "SAM_10", "id": 0},         "to": {"map": "SAM_10", "id": "RBlockA"}, "reqs": [require(item="StarStone")]}, #* Shiver Mountain Peaks Exit West -> RBlockA (MegaJump)
+    {"from": {"map": "SAM_10", "id": 0},         "to": {"map": "SAM_10", "id": "RBlockA"}, "reqs": [["StarStone"]]}, #* Shiver Mountain Peaks Exit West -> RBlockA (MegaJump)
     {"from": {"map": "SAM_10", "id": "RBlockA"}, "to": {"map": "SAM_10", "id": 0},         "reqs": []}, #* RBlockA (MegaJump) -> Shiver Mountain Peaks Exit West
-    {"from": {"map": "SAM_10", "id": 0},         "to": {"map": "SAM_10", "id": "ItemA"},   "reqs": [require(item="StarStone")]}, #* Shiver Mountain Peaks Exit West -> ItemA (StarPiece)
+    {"from": {"map": "SAM_10", "id": 0},         "to": {"map": "SAM_10", "id": "ItemA"},   "reqs": [["StarStone"]]}, #* Shiver Mountain Peaks Exit West -> ItemA (StarPiece)
     {"from": {"map": "SAM_10", "id": "ItemA"},   "to": {"map": "SAM_10", "id": 0},         "reqs": []}, #* ItemA (StarPiece) -> Shiver Mountain Peaks Exit West
 
     # SAM_11 Shiver City Pond Area
     {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_02", "id": 1}, "reqs": []}, # Shiver City Pond Area Exit West -> Shiver City Center Exit East
     {"from": {"map": "SAM_11", "id": 1}, "to": {"map": "SAM_03", "id": 0}, "reqs": []}, # Shiver City Pond Area Exit East -> Road to Shiver Snowfield Exit West
     
-    {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_11", "id": 1}, "reqs": [require(flag="RF_Ch7_MurderMysterySolved")]}, #? Shiver City Pond Area Exit West -> Shiver City Pond Area Exit East
+    {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_11", "id": 1}, "reqs": [["RF_Ch7_MurderMysterySolved"]]}, #? Shiver City Pond Area Exit West -> Shiver City Pond Area Exit East
     {"from": {"map": "SAM_11", "id": 1}, "to": {"map": "SAM_11", "id": 0}, "reqs": []}, #? Shiver City Pond Area Exit East -> Shiver City Pond Area Exit West
 
-    {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_11", "id": 0}, "reqs": [require(flag="RF_Ch7_MurderMysteryStarted"), require(item="WarehouseKey")], "pseudoitems": ["RF_Ch7_SpokeWithHerringway"]}, #+ Shiver City Pond Area Exit West
+    {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_11", "id": 0}, "reqs": [["RF_Ch7_MurderMysteryStarted"],["WarehouseKey"]], "pseudoitems": ["RF_Ch7_SpokeWithHerringway"]}, #+ Shiver City Pond Area Exit West
     
-    {"from": {"map": "SAM_11", "id": 0},       "to": {"map": "SAM_11", "id": "ItemA"}, "reqs": [require(partner="Bombette",boots=2), require(partner="Sushie"), require(flag="RF_Ch7_MurderMysteryStarted")]}, #* Shiver City Pond Area Exit West -> ItemA (WarehouseKey)
+    {"from": {"map": "SAM_11", "id": 0},       "to": {"map": "SAM_11", "id": "ItemA"}, "reqs": [["Bombette","SuperBoots"],["Sushie"],["RF_Ch7_MurderMysteryStarted"]]}, #* Shiver City Pond Area Exit West -> ItemA (WarehouseKey)
     {"from": {"map": "SAM_11", "id": "ItemA"}, "to": {"map": "SAM_11", "id": 0},       "reqs": []}, #* ItemA (WarehouseKey) -> Shiver City Pond Area Exit West
 
     {"from": {"map": "SAM_11", "id": 0}, "to": {"map": "SAM_11", "id": 0}, "reqs": [], "pseudoitems": ["StarPiece_SAM_1",

--- a/maps/graph_edges/edges_sbk.py
+++ b/maps/graph_edges/edges_sbk.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the SBK (Dry Dry Desert) area."""
 edges_sbk = [
     # SBK_00 N3W3
@@ -9,9 +7,9 @@ edges_sbk = [
     {"from": {"map": "SBK_00", "id": 1}, "to": {"map": "SBK_00", "id": 3}, "reqs": []}, #? N3W3 Exit East -> N3W3 Exit South
     {"from": {"map": "SBK_00", "id": 3}, "to": {"map": "SBK_00", "id": 1}, "reqs": []}, #? N3W3 Exit South -> N3W3 Exit East
     
-    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N3W3 Exit East -> YBlockA (FrightJar)
+    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N3W3 Exit East -> YBlockA (FrightJar)
     {"from": {"map": "SBK_00", "id": "YBlockA"}, "to": {"map": "SBK_00", "id": 1},         "reqs": []}, #* YBlockA (FrightJar) -> N3W3 Exit East
-    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N3W3 Exit East -> YBlockB (Coin)
+    {"from": {"map": "SBK_00", "id": 1},         "to": {"map": "SBK_00", "id": "YBlockB"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N3W3 Exit East -> YBlockB (Coin)
     {"from": {"map": "SBK_00", "id": "YBlockB"}, "to": {"map": "SBK_00", "id": 1},         "reqs": []}, #* YBlockB (Coin) -> N3W3 Exit East
 
     # SBK_01 N3W2
@@ -34,7 +32,7 @@ edges_sbk = [
     {"from": {"map": "SBK_02", "id": 1}, "to": {"map": "SBK_02", "id": 0}, "reqs": []}, #? N3W1 Ruins Entrance Exit East -> N3W1 Ruins Entrance Exit West
     {"from": {"map": "SBK_02", "id": 0}, "to": {"map": "SBK_02", "id": 3}, "reqs": []}, #? N3W1 Ruins Entrance Exit West -> N3W1 Ruins Entrance Exit South
     {"from": {"map": "SBK_02", "id": 3}, "to": {"map": "SBK_02", "id": 0}, "reqs": []}, #? N3W1 Ruins Entrance Exit South -> N3W1 Ruins Entrance Exit West
-    {"from": {"map": "SBK_02", "id": 0}, "to": {"map": "SBK_02", "id": 4}, "reqs": [require(item="PulseStone")]}, #? N3W1 Ruins Entrance Exit West -> N3W1 Ruins Entrance Enter Ruins
+    {"from": {"map": "SBK_02", "id": 0}, "to": {"map": "SBK_02", "id": 4}, "reqs": [["PulseStone"]]}, #? N3W1 Ruins Entrance Exit West -> N3W1 Ruins Entrance Enter Ruins
     {"from": {"map": "SBK_02", "id": 4}, "to": {"map": "SBK_02", "id": 0}, "reqs": []}, #? N3W1 Ruins Entrance Enter Ruins -> N3W1 Ruins Entrance Exit West
 
     # SBK_03 N3
@@ -90,7 +88,7 @@ edges_sbk = [
     {"from": {"map": "SBK_10", "id": 1}, "to": {"map": "SBK_10", "id": 3}, "reqs": []}, #? N2W3 Exit East -> N2W3 Exit South
     {"from": {"map": "SBK_10", "id": 3}, "to": {"map": "SBK_10", "id": 1}, "reqs": []}, #? N2W3 Exit South -> N2W3 Exit East
     
-    {"from": {"map": "SBK_10", "id": 1},               "to": {"map": "SBK_10", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* N2W3 Exit East -> HiddenYBlockA (ThunderRage)
+    {"from": {"map": "SBK_10", "id": 1},               "to": {"map": "SBK_10", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* N2W3 Exit East -> HiddenYBlockA (ThunderRage)
     {"from": {"map": "SBK_10", "id": "HiddenYBlockA"}, "to": {"map": "SBK_10", "id": 1},               "reqs": []}, #* HiddenYBlockA (ThunderRage) -> N2W3 Exit East
 
     # SBK_11 N2W2
@@ -148,9 +146,9 @@ edges_sbk = [
     {"from": {"map": "SBK_14", "id": 0}, "to": {"map": "SBK_14", "id": 4}, "reqs": []}, #? N2E1 (Tweester A) Exit West -> N2E1 (Tweester A) Tweester
     {"from": {"map": "SBK_14", "id": 4}, "to": {"map": "SBK_14", "id": 0}, "reqs": []}, #? N2E1 (Tweester A) Tweester -> N2E1 (Tweester A) Exit West
     
-    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N2E1 (Tweester A) Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N2E1 (Tweester A) Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_14", "id": "YBlockA"}, "to": {"map": "SBK_14", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> N2E1 (Tweester A) Exit West
-    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N2E1 (Tweester A) Exit West -> YBlockB (HoneySyrup)
+    {"from": {"map": "SBK_14", "id": 0},         "to": {"map": "SBK_14", "id": "YBlockB"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N2E1 (Tweester A) Exit West -> YBlockB (HoneySyrup)
     {"from": {"map": "SBK_14", "id": "YBlockB"}, "to": {"map": "SBK_14", "id": 0},         "reqs": []}, #* YBlockB (HoneySyrup) -> N2E1 (Tweester A) Exit West
 
     # SBK_15 N2E2
@@ -186,11 +184,11 @@ edges_sbk = [
     {"from": {"map": "SBK_20", "id": 1}, "to": {"map": "SBK_20", "id": 3}, "reqs": []}, #? N1W3 Special Block Exit East -> N1W3 Special Block Exit South
     {"from": {"map": "SBK_20", "id": 3}, "to": {"map": "SBK_20", "id": 1}, "reqs": []}, #? N1W3 Special Block Exit South -> N1W3 Special Block Exit East
     
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockA (Mushroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W3 Special Block Exit East -> YBlockA (Mushroom)
     {"from": {"map": "SBK_20", "id": "YBlockA"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockA (Mushroom) -> N1W3 Special Block Exit East
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockB (SuperShroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockB"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W3 Special Block Exit East -> YBlockB (SuperShroom)
     {"from": {"map": "SBK_20", "id": "YBlockB"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockB (SuperShroom) -> N1W3 Special Block Exit East
-    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W3 Special Block Exit East -> YBlockC (UltraShroom)
+    {"from": {"map": "SBK_20", "id": 1},         "to": {"map": "SBK_20", "id": "YBlockC"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W3 Special Block Exit East -> YBlockC (UltraShroom)
     {"from": {"map": "SBK_20", "id": "YBlockC"}, "to": {"map": "SBK_20", "id": 1},         "reqs": []}, #* YBlockC (UltraShroom) -> N1W3 Special Block Exit East
 
     # SBK_21 N1W2
@@ -219,15 +217,15 @@ edges_sbk = [
     {"from": {"map": "SBK_22", "id": 0}, "to": {"map": "SBK_22", "id": 3}, "reqs": []}, #? N1W1 Exit West -> N1W1 Exit South
     {"from": {"map": "SBK_22", "id": 3}, "to": {"map": "SBK_22", "id": 0}, "reqs": []}, #? N1W1 Exit South -> N1W1 Exit West
     
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockA"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockB"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockB (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockB"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W1 Exit West -> YBlockB (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockB"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockB (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockC"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockC (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockC"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W1 Exit West -> YBlockC (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockC"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockC (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockD"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockD (Coin)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockD"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W1 Exit West -> YBlockD (Coin)
     {"from": {"map": "SBK_22", "id": "YBlockD"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockD (Coin) -> N1W1 Exit West
-    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockE"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* N1W1 Exit West -> YBlockE (FireFlower)
+    {"from": {"map": "SBK_22", "id": 0},         "to": {"map": "SBK_22", "id": "YBlockE"}, "reqs": [["can_hit_grounded_blocks"]]}, #* N1W1 Exit West -> YBlockE (FireFlower)
     {"from": {"map": "SBK_22", "id": "YBlockE"}, "to": {"map": "SBK_22", "id": 0},         "reqs": []}, #* YBlockE (FireFlower) -> N1W1 Exit West
 
     # SBK_23 N1 (Tweester B)
@@ -262,7 +260,7 @@ edges_sbk = [
     {"from": {"map": "SBK_24", "id": 0}, "to": {"map": "SBK_24", "id": 4}, "reqs": []}, #? N1E1 Palm Trio Exit West -> N1E1 Palm Trio Fall From Sky
     {"from": {"map": "SBK_24", "id": 4}, "to": {"map": "SBK_24", "id": 0}, "reqs": []}, #? N1E1 Palm Trio Fall From Sky -> N1E1 Palm Trio Exit West
     
-    {"from": {"map": "SBK_24", "id": 0},               "to": {"map": "SBK_24", "id": "HiddenRBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* N1E1 Palm Trio Exit West -> HiddenRBlockA (RunawayPay)
+    {"from": {"map": "SBK_24", "id": 0},               "to": {"map": "SBK_24", "id": "HiddenRBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* N1E1 Palm Trio Exit West -> HiddenRBlockA (RunawayPay)
     {"from": {"map": "SBK_24", "id": "HiddenRBlockA"}, "to": {"map": "SBK_24", "id": 0},               "reqs": []}, #* HiddenRBlockA (RunawayPay) -> N1E1 Palm Trio Exit West
 
     # SBK_25 N1E2
@@ -301,7 +299,7 @@ edges_sbk = [
     {"from": {"map": "SBK_30", "id": 0}, "to": {"map": "SBK_30", "id": 3}, "reqs": []}, #? W3 Kolorado's Camp Exit West -> W3 Kolorado's Camp Exit South
     {"from": {"map": "SBK_30", "id": 3}, "to": {"map": "SBK_30", "id": 0}, "reqs": []}, #? W3 Kolorado's Camp Exit South -> W3 Kolorado's Camp Exit West
     
-    {"from": {"map": "SBK_30", "id": 0},              "to": {"map": "SBK_30", "id": "Tree2_Drop1A"}, "reqs": [require(flag="RF_Ch2_SavedStarSpirit"), can_shake_trees]}, #* W3 Kolorado's Camp Exit West -> Tree2_Drop1A (Letter02)
+    {"from": {"map": "SBK_30", "id": 0},              "to": {"map": "SBK_30", "id": "Tree2_Drop1A"}, "reqs": [["RF_Ch2_SavedStarSpirit"], ["can_shake_trees"]]}, #* W3 Kolorado's Camp Exit West -> Tree2_Drop1A (Letter02)
     {"from": {"map": "SBK_30", "id": "Tree2_Drop1A"}, "to": {"map": "SBK_30", "id": 0},              "reqs": []}, #* Tree2_Drop1A (Letter02) -> W3 Kolorado's Camp Exit West
 
     {"from": {"map": "SBK_30", "id": 0}, "to": {"map": "SBK_30", "id": 0}, "reqs": [], "pseudoitems": ["RF_CanVisitDesertCamp"]}, #+ Can trade Artifact in camp
@@ -351,7 +349,7 @@ edges_sbk = [
     {"from": {"map": "SBK_33", "id": 0}, "to": {"map": "SBK_33", "id": 4}, "reqs": []}, #? Center (Tweester C) Exit West -> Center (Tweester C) Tweester
     {"from": {"map": "SBK_33", "id": 4}, "to": {"map": "SBK_33", "id": 0}, "reqs": []}, #? Center (Tweester C) Tweester -> Center (Tweester C) Exit West
     
-    {"from": {"map": "SBK_33", "id": 0},             "to": {"map": "SBK_33", "id": "HiddenPanel"}, "reqs": [can_flip_panels]}, #* Center (Tweester C) Exit West -> HiddenPanel (StarPiece)
+    {"from": {"map": "SBK_33", "id": 0},             "to": {"map": "SBK_33", "id": "HiddenPanel"}, "reqs": [["can_flip_panels"]]}, #* Center (Tweester C) Exit West -> HiddenPanel (StarPiece)
     {"from": {"map": "SBK_33", "id": "HiddenPanel"}, "to": {"map": "SBK_33", "id": 0},             "reqs": []}, #* HiddenPanel (StarPiece) -> Center (Tweester C) Exit West
 
     # SBK_34 E1 Nomadimouse
@@ -393,7 +391,7 @@ edges_sbk = [
     {"from": {"map": "SBK_36", "id": 0}, "to": {"map": "SBK_36", "id": 3}, "reqs": []}, #? E3 Outside Outpost Exit West -> E3 Outside Outpost Exit South
     {"from": {"map": "SBK_36", "id": 3}, "to": {"map": "SBK_36", "id": 0}, "reqs": []}, #? E3 Outside Outpost Exit South -> E3 Outside Outpost Exit West
     
-    {"from": {"map": "SBK_36", "id": 0},              "to": {"map": "SBK_36", "id": "Tree9_Drop1A"}, "reqs": [can_shake_trees]}, #* E3 Outside Outpost Exit West -> Tree9_Drop1A (Letter03)
+    {"from": {"map": "SBK_36", "id": 0},              "to": {"map": "SBK_36", "id": "Tree9_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* E3 Outside Outpost Exit West -> Tree9_Drop1A (Letter03)
     {"from": {"map": "SBK_36", "id": "Tree9_Drop1A"}, "to": {"map": "SBK_36", "id": 0},              "reqs": []}, #* Tree9_Drop1A (Letter03) -> E3 Outside Outpost Exit West
 
     # SBK_40 S1W3
@@ -448,7 +446,7 @@ edges_sbk = [
     {"from": {"map": "SBK_43", "id": 0}, "to": {"map": "SBK_43", "id": 3}, "reqs": []}, #? S1 Exit West -> S1 Exit South
     {"from": {"map": "SBK_43", "id": 3}, "to": {"map": "SBK_43", "id": 0}, "reqs": []}, #? S1 Exit South -> S1 Exit West
     
-    {"from": {"map": "SBK_43", "id": 0},         "to": {"map": "SBK_43", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_43", "id": 0},         "to": {"map": "SBK_43", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* S1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_43", "id": "YBlockA"}, "to": {"map": "SBK_43", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> S1 Exit West
 
     # SBK_44 S1E1
@@ -479,7 +477,7 @@ edges_sbk = [
     {"from": {"map": "SBK_45", "id": 3}, "to": {"map": "SBK_45", "id": 0}, "reqs": []}, #? S1E2 Small Bluffs Exit South -> S1E2 Small Bluffs Exit West
     {"from": {"map": "SBK_45", "id": 4}, "to": {"map": "SBK_45", "id": 0}, "reqs": []}, #? S1E2 Small Bluffs Fall From Sky -> S1E2 Small Bluffs Exit West
     
-    {"from": {"map": "SBK_45", "id": 0},       "to": {"map": "SBK_45", "id": "ItemA"}, "reqs": [require(boots=3,partner="Kooper")]}, #* S1E2 Small Bluffs Exit West -> ItemA (StopWatch)
+    {"from": {"map": "SBK_45", "id": 0},       "to": {"map": "SBK_45", "id": "ItemA"}, "reqs": [["Kooper","UltraBoots"]]}, #* S1E2 Small Bluffs Exit West -> ItemA (StopWatch)
     {"from": {"map": "SBK_45", "id": "ItemA"}, "to": {"map": "SBK_45", "id": 0},       "reqs": []}, #* ItemA (StopWatch) -> S1E2 Small Bluffs Exit West
     {"from": {"map": "SBK_45", "id": 4},       "to": {"map": "SBK_45", "id": "ItemB"}, "reqs": []}, #* S1E2 Small Bluffs Exit West -> ItemB (SpinAttack)
     {"from": {"map": "SBK_45", "id": "ItemB"}, "to": {"map": "SBK_45", "id": 4},       "reqs": []}, #* ItemB (SpinAttack) -> S1E2 Small Bluffs Exit West
@@ -494,9 +492,9 @@ edges_sbk = [
     {"from": {"map": "SBK_46", "id": 0}, "to": {"map": "SBK_46", "id": 3}, "reqs": []}, #? S1E3 North of Oasis Exit West -> S1E3 North of Oasis Exit South
     {"from": {"map": "SBK_46", "id": 3}, "to": {"map": "SBK_46", "id": 0}, "reqs": []}, #? S1E3 North of Oasis Exit South -> S1E3 North of Oasis Exit West
     
-    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* S1E3 North of Oasis Exit West -> HiddenYBlockA (LifeShroom)
+    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* S1E3 North of Oasis Exit West -> HiddenYBlockA (LifeShroom)
     {"from": {"map": "SBK_46", "id": "HiddenYBlockA"}, "to": {"map": "SBK_46", "id": 0},               "reqs": []}, #* HiddenYBlockA (LifeShroom) -> S1E3 North of Oasis Exit West
-    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "YBlockA"},       "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S1E3 North of Oasis Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_46", "id": 0},               "to": {"map": "SBK_46", "id": "YBlockA"},       "reqs": [["can_hit_grounded_blocks"]]}, #* S1E3 North of Oasis Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_46", "id": "YBlockA"},       "to": {"map": "SBK_46", "id": 0},               "reqs": []}, #* YBlockA (Coin) -> S1E3 North of Oasis Exit West
 
     # SBK_50 S2W3
@@ -590,9 +588,9 @@ edges_sbk = [
     {"from": {"map": "SBK_56", "id": 0}, "to": {"map": "SBK_56", "id": 3}, "reqs": []}, #? S2E3 Oasis Exit West -> S2E3 Oasis Exit South
     {"from": {"map": "SBK_56", "id": 3}, "to": {"map": "SBK_56", "id": 0}, "reqs": []}, #? S2E3 Oasis Exit South -> S2E3 Oasis Exit West
     
-    {"from": {"map": "SBK_56", "id": 0},              "to": {"map": "SBK_56", "id": "Tree1_Drop1A"}, "reqs": [can_shake_trees]}, #* S2E3 Oasis Exit West -> Tree1_Drop1A (Lemon)
+    {"from": {"map": "SBK_56", "id": 0},              "to": {"map": "SBK_56", "id": "Tree1_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* S2E3 Oasis Exit West -> Tree1_Drop1A (Lemon)
     {"from": {"map": "SBK_56", "id": "Tree1_Drop1A"}, "to": {"map": "SBK_56", "id": 0},              "reqs": []}, #* Tree1_Drop1A (Lemon) -> S2E3 Oasis Exit West
-    {"from": {"map": "SBK_56", "id": 0},              "to": {"map": "SBK_56", "id": "Tree2_Drop1A"}, "reqs": [can_shake_trees]}, #* S2E3 Oasis Exit West -> Tree2_Drop1A (Lime)
+    {"from": {"map": "SBK_56", "id": 0},              "to": {"map": "SBK_56", "id": "Tree2_Drop1A"}, "reqs": [["can_shake_trees"]]}, #* S2E3 Oasis Exit West -> Tree2_Drop1A (Lime)
     {"from": {"map": "SBK_56", "id": "Tree2_Drop1A"}, "to": {"map": "SBK_56", "id": 0},              "reqs": []}, #* Tree2_Drop1A (Lime) -> S2E3 Oasis Exit West
 
     # SBK_60 S3W3
@@ -612,7 +610,7 @@ edges_sbk = [
     {"from": {"map": "SBK_61", "id": 0}, "to": {"map": "SBK_61", "id": 2}, "reqs": []}, #? S3W2 Hidden AttackFX Exit West -> S3W2 Hidden AttackFX Exit North
     {"from": {"map": "SBK_61", "id": 2}, "to": {"map": "SBK_61", "id": 0}, "reqs": []}, #? S3W2 Hidden AttackFX Exit North -> S3W2 Hidden AttackFX Exit West
     
-    {"from": {"map": "SBK_61", "id": 0},               "to": {"map": "SBK_61", "id": "HiddenRBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* S3W2 Hidden AttackFX Exit West -> HiddenRBlockA (AttackFXC)
+    {"from": {"map": "SBK_61", "id": 0},               "to": {"map": "SBK_61", "id": "HiddenRBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* S3W2 Hidden AttackFX Exit West -> HiddenRBlockA (AttackFXC)
     {"from": {"map": "SBK_61", "id": "HiddenRBlockA"}, "to": {"map": "SBK_61", "id": 0},               "reqs": []}, #* HiddenRBlockA (AttackFXC) -> S3W2 Hidden AttackFX Exit West
 
     # SBK_62 S3W1
@@ -645,7 +643,7 @@ edges_sbk = [
     {"from": {"map": "SBK_64", "id": 0}, "to": {"map": "SBK_64", "id": 2}, "reqs": []}, #? S3E1 Exit West -> S3E1 Exit North
     {"from": {"map": "SBK_64", "id": 2}, "to": {"map": "SBK_64", "id": 0}, "reqs": []}, #? S3E1 Exit North -> S3E1 Exit West
     
-    {"from": {"map": "SBK_64", "id": 0},         "to": {"map": "SBK_64", "id": "YBlockA"}, "reqs": [require(hammer=1,boots=2,partner=["Kooper","Bombette"])]}, #* S3E1 Exit West -> YBlockA (Coin)
+    {"from": {"map": "SBK_64", "id": 0},         "to": {"map": "SBK_64", "id": "YBlockA"}, "reqs": [["can_hit_grounded_blocks"]]}, #* S3E1 Exit West -> YBlockA (Coin)
     {"from": {"map": "SBK_64", "id": "YBlockA"}, "to": {"map": "SBK_64", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> S3E1 Exit West
 
     # SBK_65 S3E2

--- a/maps/graph_edges/edges_tik.py
+++ b/maps/graph_edges/edges_tik.py
@@ -246,11 +246,11 @@ edges_tik = [
     {"from": {"map": "TIK_24", "id": 0}, "to": {"map": "TIK_24", "id": 1}, "reqs": []}, #? Hall to Ultra Boots (B3) Exit Left -> Hall to Ultra Boots (B3) Exit Right
     {"from": {"map": "TIK_24", "id": 1}, "to": {"map": "TIK_24", "id": 0}, "reqs": [["UltraHammer"]]}, #? Hall to Ultra Boots (B3) Exit Right -> Hall to Ultra Boots (B3) Exit Left
     
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "HiddenYBlockA"}, "reqs": [["UltraHammer"],["can_see_hidden_blocks"]]}, #* Hall to Ultra Boots (B3) Exit Right -> HiddenYBlockA (LifeShroom)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "HiddenYBlockA"}, "reqs": [["UltraBoots"],["can_see_hidden_blocks"]]}, #* Hall to Ultra Boots (B3) Exit Right -> HiddenYBlockA (LifeShroom)
     {"from": {"map": "TIK_24", "id": "HiddenYBlockA"}, "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* HiddenYBlockA (LifeShroom) -> Hall to Ultra Boots (B3) Exit Right
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockA"},       "reqs": [["UltraHammer"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockA (Coin)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockA"},       "reqs": [["UltraBoots"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockA (Coin)
     {"from": {"map": "TIK_24", "id": "YBlockA"},       "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* YBlockA (Coin) -> Hall to Ultra Boots (B3) Exit Right
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockB"},       "reqs": [["UltraHammer"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockB (Coin)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockB"},       "reqs": [["UltraBoots"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockB (Coin)
     {"from": {"map": "TIK_24", "id": "YBlockB"},       "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* YBlockB (Coin) -> Hall to Ultra Boots (B3) Exit Right
 
     # TIK_25 Ultra Boots Room (B3)

--- a/maps/graph_edges/edges_tik.py
+++ b/maps/graph_edges/edges_tik.py
@@ -1,5 +1,3 @@
-from rando_modules.simulate import *
-
 """This file represents all edges of the world graph that have origin-nodes in the TIK (Toad Town Tunnels) area."""
 edges_tik = [
     # TIK_01 Warp Zone 1 (B1)
@@ -11,11 +9,11 @@ edges_tik = [
     
     {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 1}, "reqs": []}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Exit Left
     {"from": {"map": "TIK_01", "id": 1}, "to": {"map": "TIK_01", "id": 0}, "reqs": []}, #? Warp Zone 1 (B1) Exit Left -> Warp Zone 1 (B1) Exit Right
-    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 2}, "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Right)
+    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 2}, "reqs": [["GF_TIK01_WarpPipes"]]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Right)
     {"from": {"map": "TIK_01", "id": 2}, "to": {"map": "TIK_01", "id": 0}, "reqs": []}, #? Warp Zone 1 (B1) Blue Warp Pipe (Right) -> Warp Zone 1 (B1) Exit Right
-    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 3}, "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Center)
+    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 3}, "reqs": [["GF_TIK01_WarpPipes"]]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Center)
     {"from": {"map": "TIK_01", "id": 3}, "to": {"map": "TIK_01", "id": 0}, "reqs": []}, #? Warp Zone 1 (B1) Blue Warp Pipe (Center) -> Warp Zone 1 (B1) Exit Right
-    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 4}, "reqs": [require(flag="GF_TIK01_WarpPipes")]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Left)
+    {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 4}, "reqs": [["GF_TIK01_WarpPipes"]]}, #? Warp Zone 1 (B1) Exit Right -> Warp Zone 1 (B1) Blue Warp Pipe (Left)
     {"from": {"map": "TIK_01", "id": 4}, "to": {"map": "TIK_01", "id": 0}, "reqs": []}, #? Warp Zone 1 (B1) Blue Warp Pipe (Left) -> Warp Zone 1 (B1) Exit Right
     
     {"from": {"map": "TIK_01", "id": 0}, "to": {"map": "TIK_01", "id": 0}, "reqs": [], "pseudoitems": ["GF_TIK01_WarpPipes"]}, #+ Warp Zone 1 (B1) Exit Right
@@ -66,11 +64,11 @@ edges_tik = [
     {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "MAC_02", "id": 4}, "reqs": []}, # Sewer Entrance (B1) Green Pipe Up -> Southern District Open Pipe
     {"from": {"map": "TIK_06", "id": 4}, "to": {"map": "TIK_08", "id": 2}, "reqs": []}, # Sewer Entrance (B1) Hole In Ground -> Second Level Entry (B2) Hole In Ceiling
 
-    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 0}, "reqs": [require(hammer=2)]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Exit Left
+    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 0}, "reqs": [["SuperHammer"]]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Exit Left
     {"from": {"map": "TIK_06", "id": 0}, "to": {"map": "TIK_06", "id": 3}, "reqs": []}, #? Sewer Entrance (B1) Exit Left -> Sewer Entrance (B1) Green Pipe Up
-    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 1}, "reqs": [require(hammer=1)]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Exit Right
+    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 1}, "reqs": [["Hammer"]]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Exit Right
     {"from": {"map": "TIK_06", "id": 1}, "to": {"map": "TIK_06", "id": 3}, "reqs": []}, #? Sewer Entrance (B1) Exit Right -> Sewer Entrance (B1) Green Pipe Up
-    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 4}, "reqs": [require(boots=2)]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Hole In Ground
+    {"from": {"map": "TIK_06", "id": 3}, "to": {"map": "TIK_06", "id": 4}, "reqs": [["SuperBoots"]]}, #? Sewer Entrance (B1) Green Pipe Up -> Sewer Entrance (B1) Hole In Ground
     {"from": {"map": "TIK_06", "id": 4}, "to": {"map": "TIK_06", "id": 3}, "reqs": []}, #? Sewer Entrance (B1) Hole In Ground -> Sewer Entrance (B1) Green Pipe Up
     {"from": {"map": "TIK_06", "id": 2}, "to": {"map": "TIK_06", "id": 3}, "reqs": []}, #? Sewer Entrance (B1) Green Pipe Left -> Sewer Entrance (B1) Green Pipe Up
 
@@ -82,7 +80,7 @@ edges_tik = [
     {"from": {"map": "TIK_07", "id": 0}, "to": {"map": "TIK_07", "id": 2}, "reqs": []}, #? Elevator Attic Room (B2) Exit Left -> Elevator Attic Room (B2) Green Pipe Right
     {"from": {"map": "TIK_07", "id": 1}, "to": {"map": "TIK_07", "id": 0}, "reqs": []}, #? Elevator Attic Room (B2) Green Pipe Left -> Elevator Attic Room (B2) Exit Left
     
-    {"from": {"map": "TIK_07", "id": 0},       "to": {"map": "TIK_07", "id": "ItemA"}, "reqs": [require(partner="Parakarry")]}, #* Elevator Attic Room (B2) Exit Left -> ItemA (StarPiece)
+    {"from": {"map": "TIK_07", "id": 0},       "to": {"map": "TIK_07", "id": "ItemA"}, "reqs": [["Parakarry"]]}, #* Elevator Attic Room (B2) Exit Left -> ItemA (StarPiece)
     {"from": {"map": "TIK_07", "id": "ItemA"}, "to": {"map": "TIK_07", "id": 0},       "reqs": []}, #* ItemA (StarPiece) -> Elevator Attic Room (B2) Exit Left
 
     # TIK_08 Second Level Entry (B2)
@@ -92,12 +90,12 @@ edges_tik = [
     {"from": {"map": "TIK_08", "id": 3}, "to": {"map": "TIK_06", "id": 2}, "reqs": []}, # Second Level Entry (B2) Green Pipe Left -> Sewer Entrance (B1) Green Pipe Left
     {"from": {"map": "TIK_08", "id": 4}, "to": {"map": "JAN_03", "id": 3}, "reqs": []}, # Second Level Entry (B2) Blue Warp Pipe -> Village Buildings Blue Warp Pipe
     
-    {"from": {"map": "TIK_08", "id": 0}, "to": {"map": "TIK_08", "id": 1}, "reqs": [require(partner="Sushie")]}, #? Second Level Entry (B2) Exit Left -> Second Level Entry (B2) Exit Right
-    {"from": {"map": "TIK_08", "id": 1}, "to": {"map": "TIK_08", "id": 0}, "reqs": [require(partner="Sushie")]}, #? Second Level Entry (B2) Exit Right -> Second Level Entry (B2) Exit Left
+    {"from": {"map": "TIK_08", "id": 0}, "to": {"map": "TIK_08", "id": 1}, "reqs": [["Sushie"]]}, #? Second Level Entry (B2) Exit Left -> Second Level Entry (B2) Exit Right
+    {"from": {"map": "TIK_08", "id": 1}, "to": {"map": "TIK_08", "id": 0}, "reqs": [["Sushie"]]}, #? Second Level Entry (B2) Exit Right -> Second Level Entry (B2) Exit Left
     {"from": {"map": "TIK_08", "id": 2}, "to": {"map": "TIK_08", "id": 0}, "reqs": []}, #? Second Level Entry (B2) Hole In Ceiling -> Second Level Entry (B2) Exit Left
     {"from": {"map": "TIK_08", "id": 0}, "to": {"map": "TIK_08", "id": 3}, "reqs": []}, #? Second Level Entry (B2) Exit Left -> Second Level Entry (B2) Green Pipe Left
     {"from": {"map": "TIK_08", "id": 3}, "to": {"map": "TIK_08", "id": 0}, "reqs": []}, #? Second Level Entry (B2) Green Pipe Left -> Second Level Entry (B2) Exit Left
-    {"from": {"map": "TIK_08", "id": 1}, "to": {"map": "TIK_08", "id": 4}, "reqs": [require(flag="GF_TIK08_WarpPipe")]}, #? Second Level Entry (B2) Exit Right -> Second Level Entry (B2) Blue Warp Pipe
+    {"from": {"map": "TIK_08", "id": 1}, "to": {"map": "TIK_08", "id": 4}, "reqs": [["GF_TIK08_WarpPipe"]]}, #? Second Level Entry (B2) Exit Right -> Second Level Entry (B2) Blue Warp Pipe
     {"from": {"map": "TIK_08", "id": 4}, "to": {"map": "TIK_08", "id": 1}, "reqs": []}, #? Second Level Entry (B2) Blue Warp Pipe -> Second Level Entry (B2) Exit Right
     
     {"from": {"map": "TIK_08", "id": 1}, "to": {"map": "TIK_08", "id": 1}, "reqs": [], "pseudoitems": ["GF_TIK08_WarpPipe"]}, #+ Second Level Entry (B2) Exit Right
@@ -109,7 +107,7 @@ edges_tik = [
     
     {"from": {"map": "TIK_09", "id": 0}, "to": {"map": "TIK_09", "id": 1}, "reqs": []}, #? Warp Zone 2 (B2) Exit Left -> Warp Zone 2 (B2) Exit Right
     {"from": {"map": "TIK_09", "id": 1}, "to": {"map": "TIK_09", "id": 0}, "reqs": []}, #? Warp Zone 2 (B2) Exit Right -> Warp Zone 2 (B2) Exit Left
-    {"from": {"map": "TIK_09", "id": 0}, "to": {"map": "TIK_09", "id": 2}, "reqs": [require(flag="GF_TIK09_WarpPipe")]}, #? Warp Zone 2 (B2) Exit Left -> Warp Zone 2 (B2) Blue Warp Pipe
+    {"from": {"map": "TIK_09", "id": 0}, "to": {"map": "TIK_09", "id": 2}, "reqs": [["GF_TIK09_WarpPipe"]]}, #? Warp Zone 2 (B2) Exit Left -> Warp Zone 2 (B2) Blue Warp Pipe
     {"from": {"map": "TIK_09", "id": 2}, "to": {"map": "TIK_09", "id": 0}, "reqs": []}, #? Warp Zone 2 (B2) Blue Warp Pipe -> Warp Zone 2 (B2) Exit Left
 
     {"from": {"map": "TIK_09", "id": 0}, "to": {"map": "TIK_09", "id": 0}, "reqs": [], "pseudoitems": ["GF_TIK09_WarpPipe"]}, #+ Warp Zone 2 (B2) Exit Left
@@ -117,11 +115,11 @@ edges_tik = [
     # TIK_10 Block Puzzle Room (B2)
     {"from": {"map": "TIK_10", "id": 0}, "to": {"map": "TIK_09", "id": 0}, "reqs": []}, # Block Puzzle Room (B2) Exit Right -> Warp Zone 2 (B2) Exit Left
     
-    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockA (Coin)
+    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockA (Coin)
     {"from": {"map": "TIK_10", "id": "HiddenYBlockA"}, "to": {"map": "TIK_10", "id": 0},               "reqs": []}, #* HiddenYBlockA (Coin) -> Block Puzzle Room (B2) Exit Right
-    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockB (Coin)
+    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockB (Coin)
     {"from": {"map": "TIK_10", "id": "HiddenYBlockB"}, "to": {"map": "TIK_10", "id": 0},               "reqs": []}, #* HiddenYBlockB (Coin) -> Block Puzzle Room (B2) Exit Right
-    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockC"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockC (Coin)
+    {"from": {"map": "TIK_10", "id": 0},               "to": {"map": "TIK_10", "id": "HiddenYBlockC"}, "reqs": [["can_see_hidden_blocks"]]}, #* Block Puzzle Room (B2) Exit Right -> HiddenYBlockC (Coin)
     {"from": {"map": "TIK_10", "id": "HiddenYBlockC"}, "to": {"map": "TIK_10", "id": 0},               "reqs": []}, #* HiddenYBlockC (Coin) -> Block Puzzle Room (B2) Exit Right
 
     # TIK_12 Metal Block Room (B3)
@@ -131,7 +129,7 @@ edges_tik = [
     {"from": {"map": "TIK_14", "id": 0}, "to": {"map": "TIK_21", "id": 2}, "reqs": []}, # Rip Cheato Antechamber (B3) Green Pipe Left -> Hidden Blocks Room (B2) Green Pipe BottomRight
     {"from": {"map": "TIK_14", "id": 1}, "to": {"map": "TIK_15", "id": 0}, "reqs": []}, # Rip Cheato Antechamber (B3) Bomb Wall Right -> Rip Cheato's Home (B3) Bomb Wall Left
     
-    {"from": {"map": "TIK_14", "id": 0}, "to": {"map": "TIK_14", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Rip Cheato Antechamber (B3) Green Pipe Left -> Rip Cheato Antechamber (B3) Bomb Wall Right
+    {"from": {"map": "TIK_14", "id": 0}, "to": {"map": "TIK_14", "id": 1}, "reqs": [["Bombette"]]}, #? Rip Cheato Antechamber (B3) Green Pipe Left -> Rip Cheato Antechamber (B3) Bomb Wall Right
     {"from": {"map": "TIK_14", "id": 1}, "to": {"map": "TIK_14", "id": 0}, "reqs": []}, #? Rip Cheato Antechamber (B3) Bomb Wall Right -> Rip Cheato Antechamber (B3) Green Pipe Left
 
     # TIK_15 Rip Cheato's Home (B3)
@@ -139,7 +137,7 @@ edges_tik = [
     {"from": {"map": "TIK_15", "id": 1}, "to": {"map": "MAC_02", "id": 5}, "reqs": []}, # Rip Cheato's Home (B3) Green Pipe Right -> Southern District Blue House Pipe
     
     {"from": {"map": "TIK_15", "id": 0}, "to": {"map": "TIK_15", "id": 1}, "reqs": []}, #? Rip Cheato's Home (B3) Bomb Wall Left -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1}, "to": {"map": "TIK_15", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Rip Cheato's Home (B3) Green Pipe Right -> Rip Cheato's Home (B3) Bomb Wall Left
+    {"from": {"map": "TIK_15", "id": 1}, "to": {"map": "TIK_15", "id": 0}, "reqs": [["Bombette"]]}, #? Rip Cheato's Home (B3) Green Pipe Right -> Rip Cheato's Home (B3) Bomb Wall Left
 
     {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftA"}, "reqs": []}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftA (StarPiece3F 2 coins)
     {"from": {"map": "TIK_15", "id": "GiftA"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftA (StarPiece3F 2 coins) -> Rip Cheato's Home (B3) Green Pipe Right
@@ -153,15 +151,15 @@ edges_tik = [
     {"from": {"map": "TIK_15", "id": "GiftE"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftE (StarPiece40 8 coins) -> Rip Cheato's Home (B3) Green Pipe Right
     {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftF"}, "reqs": []}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftF (SuperShroom 8 coins)
     {"from": {"map": "TIK_15", "id": "GiftF"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftF (SuperShroom 8 coins) -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftG"}, "reqs": [require(flag="RF_OutOfLogic")]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftG (Mushroom 16 coins)
+    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftG"}, "reqs": [["RF_OutOfLogic"]]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftG (Mushroom 16 coins)
     {"from": {"map": "TIK_15", "id": "GiftG"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftG (Mushroom 16 coins) -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftH"}, "reqs": [require(flag="RF_OutOfLogic")]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftH (DriedShroom 16 coins)
+    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftH"}, "reqs": [["RF_OutOfLogic"]]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftH (DriedShroom 16 coins)
     {"from": {"map": "TIK_15", "id": "GiftH"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftH (DriedShroom 16 coins) -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftI"}, "reqs": [require(flag="RF_OutOfLogic")]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftI (DriedShroom 32 coins)
+    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftI"}, "reqs": [["RF_OutOfLogic"]]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftI (DriedShroom 32 coins)
     {"from": {"map": "TIK_15", "id": "GiftI"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftI (DriedShroom 32 coins) -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftJ"}, "reqs": [require(flag="RF_OutOfLogic")]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftI (StarPiece41 32 coins)
+    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftJ"}, "reqs": [["RF_OutOfLogic"]]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftI (StarPiece41 32 coins)
     {"from": {"map": "TIK_15", "id": "GiftJ"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftI (StarPiece41 32 coins) -> Rip Cheato's Home (B3) Green Pipe Right
-    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftK"}, "reqs": [require(flag="RF_OutOfLogic")]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftK (DriedShroom 64 coins)
+    {"from": {"map": "TIK_15", "id": 1},       "to": {"map": "TIK_15", "id": "GiftK"}, "reqs": [["RF_OutOfLogic"]]}, #* Rip Cheato's Home (B3) Green Pipe Right -> GiftK (DriedShroom 64 coins)
     {"from": {"map": "TIK_15", "id": "GiftK"}, "to": {"map": "TIK_15", "id": 1},       "reqs": []}, #* GiftK (DriedShroom 64 coins) -> Rip Cheato's Home (B3) Green Pipe Right
 
     # TIK_17 Frozen Room (B3)
@@ -178,7 +176,7 @@ edges_tik = [
     {"from": {"map": "TIK_18", "id": 0}, "to": {"map": "TIK_18", "id": 1}, "reqs": []}, #? Hall to Blooper 1 (B1) Exit Left -> Hall to Blooper 1 (B1) Exit Right
     {"from": {"map": "TIK_18", "id": 1}, "to": {"map": "TIK_18", "id": 0}, "reqs": []}, #? Hall to Blooper 1 (B1) Exit Right -> Hall to Blooper 1 (B1) Exit Left
     
-    {"from": {"map": "TIK_18", "id": 0},               "to": {"map": "TIK_18", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Hall to Blooper 1 (B1) Exit Left -> HiddenYBlockA (SuperShroom)
+    {"from": {"map": "TIK_18", "id": 0},               "to": {"map": "TIK_18", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Hall to Blooper 1 (B1) Exit Left -> HiddenYBlockA (SuperShroom)
     {"from": {"map": "TIK_18", "id": "HiddenYBlockA"}, "to": {"map": "TIK_18", "id": 0},               "reqs": []}, #* HiddenYBlockA (SuperShroom) -> Hall to Blooper 1 (B1) Exit Left
 
     # TIK_19 Under the Toad Town Pond
@@ -191,10 +189,10 @@ edges_tik = [
     
     {"from": {"map": "TIK_20", "id": 0}, "to": {"map": "TIK_20", "id": 1}, "reqs": []}, #? Room with Spikes (B2) Exit Left -> Room with Spikes (B2) Exit Right
     {"from": {"map": "TIK_20", "id": 1}, "to": {"map": "TIK_20", "id": 0}, "reqs": []}, #? Room with Spikes (B2) Exit Right -> Room with Spikes (B2) Exit Left
-    {"from": {"map": "TIK_20", "id": 0}, "to": {"map": "TIK_20", "id": 2}, "reqs": [require(partner="Lakilester")]}, #? Room with Spikes (B2) Exit Left -> Room with Spikes (B2) Green Pipe Center
-    {"from": {"map": "TIK_20", "id": 2}, "to": {"map": "TIK_20", "id": 0}, "reqs": [require(partner="Lakilester")]}, #? Room with Spikes (B2) Green Pipe Center -> Room with Spikes (B2) Exit Left
+    {"from": {"map": "TIK_20", "id": 0}, "to": {"map": "TIK_20", "id": 2}, "reqs": [["Lakilester"]]}, #? Room with Spikes (B2) Exit Left -> Room with Spikes (B2) Green Pipe Center
+    {"from": {"map": "TIK_20", "id": 2}, "to": {"map": "TIK_20", "id": 0}, "reqs": [["Lakilester"]]}, #? Room with Spikes (B2) Green Pipe Center -> Room with Spikes (B2) Exit Left
     
-    {"from": {"map": "TIK_20", "id": 1},         "to": {"map": "TIK_20", "id": "YBlockA"}, "reqs": [require(boots=3)]}, #* Room with Spikes (B2) Exit Right -> YBlockA (ShootingStar)
+    {"from": {"map": "TIK_20", "id": 1},         "to": {"map": "TIK_20", "id": "YBlockA"}, "reqs": [["UltraBoots"]]}, #* Room with Spikes (B2) Exit Right -> YBlockA (ShootingStar)
     {"from": {"map": "TIK_20", "id": "YBlockA"}, "to": {"map": "TIK_20", "id": 1},         "reqs": []}, #* YBlockA (ShootingStar) -> Room with Spikes (B2) Exit Right
 
     # TIK_21 Hidden Blocks Room (B2)
@@ -207,15 +205,15 @@ edges_tik = [
     {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": 2}, "reqs": []}, #? Hidden Blocks Room (B2) Exit Left -> Hidden Blocks Room (B2) Green Pipe BottomRight
     {"from": {"map": "TIK_21", "id": 2}, "to": {"map": "TIK_21", "id": 0}, "reqs": []}, #? Hidden Blocks Room (B2) Green Pipe BottomRight -> Hidden Blocks Room (B2) Exit Left
     
-    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockA"}, "reqs": [require(boots=2)]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockA (Coin)
+    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockA"}, "reqs": [["SuperBoots"]]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockA (Coin)
     {"from": {"map": "TIK_21", "id": "YBlockA"}, "to": {"map": "TIK_21", "id": 0},         "reqs": []}, #* YBlockA (Coin) -> Hidden Blocks Room (B2) Exit Left
-    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockB"}, "reqs": [require(boots=2)]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockB (Coin)
+    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockB"}, "reqs": [["SuperBoots"]]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockB (Coin)
     {"from": {"map": "TIK_21", "id": "YBlockB"}, "to": {"map": "TIK_21", "id": 0},         "reqs": []}, #* YBlockB (Coin) -> Hidden Blocks Room (B2) Exit Left
-    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockC"}, "reqs": [require(boots=2)]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockC (Coin)
+    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockC"}, "reqs": [["SuperBoots"]]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockC (Coin)
     {"from": {"map": "TIK_21", "id": "YBlockC"}, "to": {"map": "TIK_21", "id": 0},         "reqs": []}, #* YBlockC (Coin) -> Hidden Blocks Room (B2) Exit Left
-    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockD"}, "reqs": [require(boots=2)]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockD (Coin)
+    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockD"}, "reqs": [["SuperBoots"]]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockD (Coin)
     {"from": {"map": "TIK_21", "id": "YBlockD"}, "to": {"map": "TIK_21", "id": 0},         "reqs": []}, #* YBlockD (Coin) -> Hidden Blocks Room (B2) Exit Left
-    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockE"}, "reqs": [require(boots=2)]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockE (Coin)
+    {"from": {"map": "TIK_21", "id": 0},         "to": {"map": "TIK_21", "id": "YBlockE"}, "reqs": [["SuperBoots"]]}, #* Hidden Blocks Room (B2) Exit Left -> YBlockE (Coin)
     {"from": {"map": "TIK_21", "id": "YBlockE"}, "to": {"map": "TIK_21", "id": 0},         "reqs": []}, #* YBlockE (Coin) -> Hidden Blocks Room (B2) Exit Left
 
     # TIK_22 Path to Shiver City (B2)
@@ -230,13 +228,13 @@ edges_tik = [
     {"from": {"map": "TIK_23", "id": 1}, "to": {"map": "TIK_20", "id": 2}, "reqs": []}, # Windy Path (B3) Green Pipe -> Room with Spikes (B2) Green Pipe Center
     
     {"from": {"map": "TIK_23", "id": 0}, "to": {"map": "TIK_23", "id": 1}, "reqs": []}, #? Windy Path (B3) Exit Left -> Windy Path (B3) Green Pipe
-    {"from": {"map": "TIK_23", "id": 1}, "to": {"map": "TIK_23", "id": 0}, "reqs": [require(hammer=2)]}, #? Windy Path (B3) Green Pipe -> Windy Path (B3) Exit Left
+    {"from": {"map": "TIK_23", "id": 1}, "to": {"map": "TIK_23", "id": 0}, "reqs": [["SuperHammer"]]}, #? Windy Path (B3) Green Pipe -> Windy Path (B3) Exit Left
     
-    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockA"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockA (MapleSyrup)
+    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockA"}, "reqs": [["can_see_hidden_blocks"]]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockA (MapleSyrup)
     {"from": {"map": "TIK_23", "id": "HiddenYBlockA"}, "to": {"map": "TIK_23", "id": 1},               "reqs": []}, #* HiddenYBlockA (MapleSyrup) -> Windy Path (B3) Green Pipe
-    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockB"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockB (StopWatch)
+    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockB"}, "reqs": [["can_see_hidden_blocks"]]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockB (StopWatch)
     {"from": {"map": "TIK_23", "id": "HiddenYBlockB"}, "to": {"map": "TIK_23", "id": 1},               "reqs": []}, #* HiddenYBlockB (StopWatch) -> Windy Path (B3) Green Pipe
-    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockC"}, "reqs": [require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockC (VoltShroom)
+    {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "HiddenYBlockC"}, "reqs": [["can_see_hidden_blocks"]]}, #* Windy Path (B3) Green Pipe -> HiddenYBlockC (VoltShroom)
     {"from": {"map": "TIK_23", "id": "HiddenYBlockC"}, "to": {"map": "TIK_23", "id": 1},               "reqs": []}, #* HiddenYBlockC (VoltShroom) -> Windy Path (B3) Green Pipe
     {"from": {"map": "TIK_23", "id": 1},               "to": {"map": "TIK_23", "id": "YBlockA"},       "reqs": []}, #* Windy Path (B3) Green Pipe -> YBlockA (Coin)
     {"from": {"map": "TIK_23", "id": "YBlockA"},       "to": {"map": "TIK_23", "id": 1},               "reqs": []}, #* YBlockA (Coin) -> Windy Path (B3) Green Pipe
@@ -246,13 +244,13 @@ edges_tik = [
     {"from": {"map": "TIK_24", "id": 1}, "to": {"map": "TIK_23", "id": 0}, "reqs": []}, # Hall to Ultra Boots (B3) Exit Right -> Windy Path (B3) Exit Left
     
     {"from": {"map": "TIK_24", "id": 0}, "to": {"map": "TIK_24", "id": 1}, "reqs": []}, #? Hall to Ultra Boots (B3) Exit Left -> Hall to Ultra Boots (B3) Exit Right
-    {"from": {"map": "TIK_24", "id": 1}, "to": {"map": "TIK_24", "id": 0}, "reqs": [require(hammer=3)]}, #? Hall to Ultra Boots (B3) Exit Right -> Hall to Ultra Boots (B3) Exit Left
+    {"from": {"map": "TIK_24", "id": 1}, "to": {"map": "TIK_24", "id": 0}, "reqs": [["UltraHammer"]]}, #? Hall to Ultra Boots (B3) Exit Right -> Hall to Ultra Boots (B3) Exit Left
     
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "HiddenYBlockA"}, "reqs": [require(boots=3),require(partner="Watt",flag="RF_HiddenBlocksVisible")]}, #* Hall to Ultra Boots (B3) Exit Right -> HiddenYBlockA (LifeShroom)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "HiddenYBlockA"}, "reqs": [["UltraHammer"],["can_see_hidden_blocks"]]}, #* Hall to Ultra Boots (B3) Exit Right -> HiddenYBlockA (LifeShroom)
     {"from": {"map": "TIK_24", "id": "HiddenYBlockA"}, "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* HiddenYBlockA (LifeShroom) -> Hall to Ultra Boots (B3) Exit Right
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockA"},       "reqs": [require(boots=3)]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockA (Coin)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockA"},       "reqs": [["UltraHammer"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockA (Coin)
     {"from": {"map": "TIK_24", "id": "YBlockA"},       "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* YBlockA (Coin) -> Hall to Ultra Boots (B3) Exit Right
-    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockB"},       "reqs": [require(boots=3)]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockB (Coin)
+    {"from": {"map": "TIK_24", "id": 1},               "to": {"map": "TIK_24", "id": "YBlockB"},       "reqs": [["UltraHammer"]]}, #* Hall to Ultra Boots (B3) Exit Right -> YBlockB (Coin)
     {"from": {"map": "TIK_24", "id": "YBlockB"},       "to": {"map": "TIK_24", "id": 1},               "reqs": []}, #* YBlockB (Coin) -> Hall to Ultra Boots (B3) Exit Right
 
     # TIK_25 Ultra Boots Room (B3)

--- a/maps/graph_edges/edges_trd.py
+++ b/maps/graph_edges/edges_trd.py
@@ -1,4 +1,3 @@
-from rando_modules.simulate import *
 """This file represents all edges of the world graph that have origin-nodes in the TRD (Koopa Bros. Fortress) area."""
 edges_trd = [
     # TRD_00 Fortress Exterior
@@ -12,7 +11,7 @@ edges_trd = [
     {"from": {"map": "TRD_00", "id": 1}, "to": {"map": "TRD_00", "id": 0}, "reqs": []}, #? Fortress Exterior Main Entrance -> Fortress Exterior Exit Bottom Left
     
     {"from": {"map": "TRD_00", "id": 3},        "to": {"map": "TRD_00", "id": "ChestA"}, "reqs": []}, #* Fortress Exterior Exit Bottom Left -> ChestA (Refund)
-    {"from": {"map": "TRD_00", "id": "ChestA"}, "to": {"map": "TRD_00", "id": 3},        "reqs": [require(partner="Bombette")]}, #* ChestA (Refund) -> Fortress Exterior Exit Bottom Left
+    {"from": {"map": "TRD_00", "id": "ChestA"}, "to": {"map": "TRD_00", "id": 3},        "reqs": [["Bombette"]]}, #* ChestA (Refund) -> Fortress Exterior Exit Bottom Left
     {"from": {"map": "TRD_00", "id": 4},        "to": {"map": "TRD_00", "id": "ChestB"}, "reqs": []}, #* Fortress Exterior Exit Bottom Left -> ChestB (FPPlusB)
     {"from": {"map": "TRD_00", "id": "ChestB"}, "to": {"map": "TRD_00", "id": 4},        "reqs": []}, #* ChestB (FPPlusB) -> Fortress Exterior Exit Bottom Left
 
@@ -22,10 +21,10 @@ edges_trd = [
     {"from": {"map": "TRD_01", "id": 2}, "to": {"map": "TRD_02", "id": 2}, "reqs": []}, # Left Tower Exit Middle Right -> Left Stairway Exit Top Left
     {"from": {"map": "TRD_01", "id": 3}, "to": {"map": "TRD_09", "id": 0}, "reqs": []}, # Left Tower Exit Top Right -> Battlement Exit Left
     
-    {"from": {"map": "TRD_01", "id": 0}, "to": {"map": "TRD_01", "id": 1}, "reqs": [require(item="KoopaFortressKey")]}, #? Left Tower Exit Bottom Left -> Left Tower Exit Bottom Right
+    {"from": {"map": "TRD_01", "id": 0}, "to": {"map": "TRD_01", "id": 1}, "reqs": [[{"KoopaFortressKey": 1}]]}, #? Left Tower Exit Bottom Left -> Left Tower Exit Bottom Right
     {"from": {"map": "TRD_01", "id": 1}, "to": {"map": "TRD_01", "id": 0}, "reqs": []}, #? Left Tower Exit Bottom Right -> Left Tower Exit Bottom Left
-    {"from": {"map": "TRD_01", "id": 2}, "to": {"map": "TRD_01", "id": 3}, "reqs": [require(flag="MF_TRD01_RaisedStairs")]}, #? Left Tower Exit Middle Right -> Left Tower Exit Top Right
-    {"from": {"map": "TRD_01", "id": 3}, "to": {"map": "TRD_01", "id": 2}, "reqs": [require(flag="MF_TRD01_RaisedStairs")]}, #? Left Tower Exit Top Right -> Left Tower Exit Middle Right
+    {"from": {"map": "TRD_01", "id": 2}, "to": {"map": "TRD_01", "id": 3}, "reqs": [["MF_TRD01_RaisedStairs"]]}, #? Left Tower Exit Middle Right -> Left Tower Exit Top Right
+    {"from": {"map": "TRD_01", "id": 3}, "to": {"map": "TRD_01", "id": 2}, "reqs": [["MF_TRD01_RaisedStairs"]]}, #? Left Tower Exit Top Right -> Left Tower Exit Middle Right
     
     {"from": {"map": "TRD_01", "id": 2}, "to": {"map": "TRD_01", "id": 2}, "reqs": [], "pseudoitems": ["MF_TRD01_RaisedStairs"]}, #+ Left Tower Exit Middle Right
     
@@ -43,12 +42,12 @@ edges_trd = [
     
     {"from": {"map": "TRD_02", "id": 0}, "to": {"map": "TRD_02", "id": 1}, "reqs": []}, #? Left Stairway Exit Bottom Left -> Left Stairway Exit Bottom Right
     {"from": {"map": "TRD_02", "id": 1}, "to": {"map": "TRD_02", "id": 0}, "reqs": []}, #? Left Stairway Exit Bottom Right -> Left Stairway Exit Bottom Left
-    {"from": {"map": "TRD_02", "id": 1}, "to": {"map": "TRD_02", "id": 4}, "reqs": [require(flag="MF_TRD02_LoweredStairs"),require(partner="Bombette")]}, #? Left Stairway Exit Bottom Right -> Left Stairway Exit Middle Right
+    {"from": {"map": "TRD_02", "id": 1}, "to": {"map": "TRD_02", "id": 4}, "reqs": [["MF_TRD02_LoweredStairs"],["Bombette"]]}, #? Left Stairway Exit Bottom Right -> Left Stairway Exit Middle Right
     {"from": {"map": "TRD_02", "id": 4}, "to": {"map": "TRD_02", "id": 1}, "reqs": []}, #? Left Stairway Exit Middle Right -> Left Stairway Exit Bottom Right
     {"from": {"map": "TRD_02", "id": 2}, "to": {"map": "TRD_02", "id": 3}, "reqs": []}, #? Left Stairway Exit Top Left -> Left Stairway Exit Top Right
-    {"from": {"map": "TRD_02", "id": 3}, "to": {"map": "TRD_02", "id": 2}, "reqs": [require(item="KoopaFortressKey")]}, #? Left Stairway Exit Top Right -> Left Stairway Exit Top Left
-    {"from": {"map": "TRD_02", "id": 3}, "to": {"map": "TRD_02", "id": 1}, "reqs": [require(flag="MF_TRD02_LoweredStairs")]}, #? Left Stairway Exit Top Right -> Left Stairway Exit Bottom Right
-    {"from": {"map": "TRD_02", "id": 1}, "to": {"map": "TRD_02", "id": 3}, "reqs": [require(flag="MF_TRD02_LoweredStairs")]}, #? Left Stairway Exit Bottom Right -> Left Stairway Exit Top Right
+    {"from": {"map": "TRD_02", "id": 3}, "to": {"map": "TRD_02", "id": 2}, "reqs": [[{"KoopaFortressKey": 4}]]}, #? Left Stairway Exit Top Right -> Left Stairway Exit Top Left
+    {"from": {"map": "TRD_02", "id": 3}, "to": {"map": "TRD_02", "id": 1}, "reqs": [["MF_TRD02_LoweredStairs"]]}, #? Left Stairway Exit Top Right -> Left Stairway Exit Bottom Right
+    {"from": {"map": "TRD_02", "id": 1}, "to": {"map": "TRD_02", "id": 3}, "reqs": [["MF_TRD02_LoweredStairs"]]}, #? Left Stairway Exit Bottom Right -> Left Stairway Exit Top Right
     
     {"from": {"map": "TRD_02", "id": 3}, "to": {"map": "TRD_02", "id": 3}, "reqs": [], "pseudoitems": ["MF_TRD02_LoweredStairs"]}, #+ Left Stairway Exit Top Right
 
@@ -61,16 +60,16 @@ edges_trd = [
     
     {"from": {"map": "TRD_03", "id": 0}, "to": {"map": "TRD_03", "id": 1}, "reqs": []}, #? Central Hall Exit Bottom Left -> Central Hall Exit Bottom Right
     {"from": {"map": "TRD_03", "id": 1}, "to": {"map": "TRD_03", "id": 0}, "reqs": []}, #? Central Hall Exit Bottom Right -> Central Hall Exit Bottom Left
-    {"from": {"map": "TRD_03", "id": 2}, "to": {"map": "TRD_03", "id": 3}, "reqs": [require(partner=["Kooper", "Parakarry"])]}, #? Central Hall Exit Top Left -> Central Hall Exit Top Right
-    {"from": {"map": "TRD_03", "id": 3}, "to": {"map": "TRD_03", "id": 2}, "reqs": [require(partner=["Kooper", "Parakarry"])]}, #? Central Hall Exit Top Right-> Central Hall Exit Top Left
+    {"from": {"map": "TRD_03", "id": 2}, "to": {"map": "TRD_03", "id": 3}, "reqs": [["Kooper","Parakarry"]]}, #? Central Hall Exit Top Left -> Central Hall Exit Top Right
+    {"from": {"map": "TRD_03", "id": 3}, "to": {"map": "TRD_03", "id": 2}, "reqs": [["Kooper","Parakarry"]]}, #? Central Hall Exit Top Right-> Central Hall Exit Top Left
     {"from": {"map": "TRD_03", "id": 2}, "to": {"map": "TRD_03", "id": 0}, "reqs": []}, #? Central Hall Exit Top Left -> Central Hall Exit Bottom Left
     {"from": {"map": "TRD_03", "id": 3}, "to": {"map": "TRD_03", "id": 1}, "reqs": []}, #? Central Hall Exit Top Right-> Central Hall Exit Bottom Right
     
     {"from": {"map": "TRD_03", "id": 4},       "to": {"map": "TRD_03", "id": "ItemA"}, "reqs": []}, #* Central Hall Exit Left Cell -> ItemA (KoopaFortressKey) (Left)
-    {"from": {"map": "TRD_03", "id": "ItemA"}, "to": {"map": "TRD_03", "id": 4},       "reqs": [require(partner="Bombette")]}, #* ItemA (KoopaFortressKey) (Left) -> Central Hall Exit Left Cell
+    {"from": {"map": "TRD_03", "id": "ItemA"}, "to": {"map": "TRD_03", "id": 4},       "reqs": [["Bombette"]]}, #* ItemA (KoopaFortressKey) (Left) -> Central Hall Exit Left Cell
     {"from": {"map": "TRD_03", "id": 0},       "to": {"map": "TRD_03", "id": "ItemC"}, "reqs": []}, #* Central Hall Exit Bottom Left -> ItemC (PowerBounce)
     {"from": {"map": "TRD_03", "id": "ItemC"}, "to": {"map": "TRD_03", "id": 0},       "reqs": []}, #* ItemC (PowerBounce) -> Central Hall Exit Bottom Left
-    {"from": {"map": "TRD_03", "id": 1},       "to": {"map": "TRD_03", "id": "ItemB"}, "reqs": [require(partner="Bombette")]}, #* Central Hall Exit Bottom Right -> ItemB (KoopaFortressKey) (Right)
+    {"from": {"map": "TRD_03", "id": 1},       "to": {"map": "TRD_03", "id": "ItemB"}, "reqs": [["Bombette"]]}, #* Central Hall Exit Bottom Right -> ItemB (KoopaFortressKey) (Right)
     {"from": {"map": "TRD_03", "id": "ItemB"}, "to": {"map": "TRD_03", "id": 1},       "reqs": []}, #* ItemB (KoopaFortressKey) (Right) -> Central Hall Exit Bottom Right
 
     # TRD_04 Right Stairway
@@ -81,14 +80,14 @@ edges_trd = [
     {"from": {"map": "TRD_04", "id": 4}, "to": {"map": "TRD_07", "id": 0}, "reqs": []}, # Right Starway Exit Bottom Left -> Dungeon Trap Exit Right
     {"from": {"map": "TRD_04", "id": 5}, "to": {"map": "TRD_06", "id": 1}, "reqs": []}, # Right Starway Exit Bottom Right -> Jail Exit Left
     
-    {"from": {"map": "TRD_04", "id": 0}, "to": {"map": "TRD_04", "id": 1}, "reqs": [require(item="KoopaFortressKey")]}, #? Right Starway Exit Middle Left -> Right Starway Exit Middle Right
+    {"from": {"map": "TRD_04", "id": 0}, "to": {"map": "TRD_04", "id": 1}, "reqs": [[{"KoopaFortressKey": 2}]]}, #? Right Starway Exit Middle Left -> Right Starway Exit Middle Right
     {"from": {"map": "TRD_04", "id": 1}, "to": {"map": "TRD_04", "id": 0}, "reqs": []}, #? Right Starway Exit Middle Right -> Right Starway Exit Middle Left
-    {"from": {"map": "TRD_04", "id": 0}, "to": {"map": "TRD_04", "id": 5}, "reqs": [require(flag="MF_TRD04_LoweredStairs")]}, #? Right Starway Exit Middle Left -> Right Starway Exit Bottom Right
-    {"from": {"map": "TRD_04", "id": 5}, "to": {"map": "TRD_04", "id": 0}, "reqs": [require(flag="MF_TRD04_LoweredStairs")]}, #? Right Starway Exit Bottom Right -> Right Starway Exit Middle Left
+    {"from": {"map": "TRD_04", "id": 0}, "to": {"map": "TRD_04", "id": 5}, "reqs": [["MF_TRD04_LoweredStairs"]]}, #? Right Starway Exit Middle Left -> Right Starway Exit Bottom Right
+    {"from": {"map": "TRD_04", "id": 5}, "to": {"map": "TRD_04", "id": 0}, "reqs": [["MF_TRD04_LoweredStairs"]]}, #? Right Starway Exit Bottom Right -> Right Starway Exit Middle Left
     {"from": {"map": "TRD_04", "id": 4}, "to": {"map": "TRD_04", "id": 5}, "reqs": []}, #? Right Starway Exit Bottom Left -> Right Starway Exit Bottom Right
     {"from": {"map": "TRD_04", "id": 5}, "to": {"map": "TRD_04", "id": 4}, "reqs": []}, #? Right Starway Exit Bottom Right -> Right Starway Exit Bottom Left
     {"from": {"map": "TRD_04", "id": 2}, "to": {"map": "TRD_04", "id": 3}, "reqs": []}, #? Right Starway Exit Top Left -> Right Starway Exit Top Right
-    {"from": {"map": "TRD_04", "id": 3}, "to": {"map": "TRD_04", "id": 2}, "reqs": [require(item="KoopaFortressKey")]}, #? Right Starway Exit Top Right -> Right Starway Exit Top Left
+    {"from": {"map": "TRD_04", "id": 3}, "to": {"map": "TRD_04", "id": 2}, "reqs": [[{"KoopaFortressKey": 3}]]}, #? Right Starway Exit Top Right -> Right Starway Exit Top Left
     {"from": {"map": "TRD_04", "id": 3}, "to": {"map": "TRD_04", "id": 0}, "reqs": []}, #? Right Starway Exit Top Right -> Right Starway Exit Middle Left
     
     {"from": {"map": "TRD_04", "id": 0}, "to": {"map": "TRD_04", "id": 0}, "reqs": [], "pseudoitems": ["MF_TRD04_LoweredStairs"]}, #+ Right Starway Exit Middle Left
@@ -104,7 +103,7 @@ edges_trd = [
 
     {"from": {"map": "TRD_05", "id": 0}, "to": {"map": "TRD_05", "id": 1}, "reqs": []}, #? Right Tower Exit Bottom Left -> Right Tower Exit Bottom Down
     {"from": {"map": "TRD_05", "id": 1}, "to": {"map": "TRD_05", "id": 0}, "reqs": []}, #? Right Tower Exit Bottom Down -> Right Tower Exit Bottom Left
-    {"from": {"map": "TRD_05", "id": 0}, "to": {"map": "TRD_05", "id": 2}, "reqs": [require(partner="Bombette")]}, #? Right Tower Exit Bottom Left -> Right Tower Exit Bottom Right
+    {"from": {"map": "TRD_05", "id": 0}, "to": {"map": "TRD_05", "id": 2}, "reqs": [["Bombette"]]}, #? Right Tower Exit Bottom Left -> Right Tower Exit Bottom Right
     {"from": {"map": "TRD_05", "id": 2}, "to": {"map": "TRD_05", "id": 0}, "reqs": []}, #? Right Tower Exit Bottom Right -> Right Tower Exit Bottom Left
     {"from": {"map": "TRD_05", "id": 0}, "to": {"map": "TRD_05", "id": 3}, "reqs": []}, #? Right Tower Exit Bottom Left -> Right Tower Exit Top Left
     {"from": {"map": "TRD_05", "id": 3}, "to": {"map": "TRD_05", "id": 0}, "reqs": []}, #? Right Tower Exit Top Left -> Right Tower Exit Bottom Left
@@ -115,8 +114,8 @@ edges_trd = [
     {"from": {"map": "TRD_06", "id": 0}, "to": {"map": None, "id": None},  "reqs": []}, # Jail Fall From Ceiling
     {"from": {"map": "TRD_06", "id": 1}, "to": {"map": "TRD_04", "id": 5}, "reqs": []}, # Jail Exit Left -> Right Starway Exit Bottom Right
     
-    {"from": {"map": "TRD_06", "id": 1}, "to": {"map": "TRD_06", "id": 0}, "reqs": [require(partner="Bombette")]}, #? Jail Exit Left -> Jail Fall From Ceiling
-    {"from": {"map": "TRD_06", "id": 0}, "to": {"map": "TRD_06", "id": 1}, "reqs": [require(partner="Bombette")]}, #? Jail Fall From Ceiling -> Jail Exit Left
+    {"from": {"map": "TRD_06", "id": 1}, "to": {"map": "TRD_06", "id": 0}, "reqs": [["Bombette"]]}, #? Jail Exit Left -> Jail Fall From Ceiling
+    {"from": {"map": "TRD_06", "id": 0}, "to": {"map": "TRD_06", "id": 1}, "reqs": [["Bombette"]]}, #? Jail Fall From Ceiling -> Jail Exit Left
     
     {"from": {"map": "TRD_06", "id": 0},         "to": {"map": "TRD_06", "id": "Partner"}, "reqs": []}, #* Jail Fall From Ceiling -> Partner (Bombette)
     {"from": {"map": "TRD_06", "id": "Partner"}, "to": {"map": "TRD_06", "id": 0},         "reqs": []}, #* Partner (Bombette) -> Jail Fall From Ceiling
@@ -141,7 +140,7 @@ edges_trd = [
     {"from": {"map": "TRD_09", "id": 0}, "to": {"map": "TRD_09", "id": 1}, "reqs": []}, #? Battlement Exit Left -> Battlement Exit Right
     {"from": {"map": "TRD_09", "id": 1}, "to": {"map": "TRD_09", "id": 0}, "reqs": []}, #? Battlement Exit Right -> Battlement Exit Left
     
-    {"from": {"map": "TRD_09", "id": 0},         "to": {"map": "TRD_09", "id": "YBlockA"}, "reqs": [require(partner="Bombette")]}, #* Battlement Exit Left -> YBlockA (MapleSyrup)
+    {"from": {"map": "TRD_09", "id": 0},         "to": {"map": "TRD_09", "id": "YBlockA"}, "reqs": [["Bombette"]]}, #* Battlement Exit Left -> YBlockA (MapleSyrup)
     {"from": {"map": "TRD_09", "id": "YBlockA"}, "to": {"map": "TRD_09", "id": 0},         "reqs": []}, #* YBlockA (MapleSyrup) -> Battlement Exit Left
 
     # TRD_10 Boss Battle Room

--- a/rando_modules/simulate.py
+++ b/rando_modules/simulate.py
@@ -98,7 +98,7 @@ class Mario:
         * Superboots or better, or
         * UltraHammer
         """
-        return len(self.hammer) == 3 or len(self.boots) >= 2
+        return ((len(self.hammer) - 1) >= 2 or len(self.boots) - 1 >= 1)
 
 
     def can_shake_trees(self):
@@ -114,7 +114,7 @@ class Mario:
         """Check if Mario is able to hit a block placed on the ground."""
         return (
             len(self.hammer) - 1 >= 0
-         or len(self.boots) >= 1
+         or len(self.boots) - 1 >= 1
          or "Kooper" in self.partners
          or "Bombette" in self.partners
         )
@@ -189,11 +189,11 @@ class Mario:
                     # Check boots
                     if req.endswith("Boots"):
                         if req == "UltraBoots":
-                            if len(self.boots) >= 2:
+                            if len(self.boots) - 1 >= 2:
                                 group_fulfilled = True
                                 break
                         elif req == "SuperBoots":
-                            if len(self.boots) >= 1:
+                            if len(self.boots) - 1 >= 1:
                                 group_fulfilled = True
                                 break
                     # Check hammer
@@ -230,6 +230,8 @@ class Mario:
                             break
                     # Check panel flipping
                     if req == "can_flip_panels":
+                        print(req)
+                        print(self.can_flip_panels())
                         if self.can_flip_panels():
                             group_fulfilled = True
                             break

--- a/rando_modules/simulate.py
+++ b/rando_modules/simulate.py
@@ -34,14 +34,15 @@ class Mario:
             if (   item_object.startswith("GF")
                 or item_object.startswith("MF")
                 or item_object.startswith("MB")
-                or item_object.startswith("RF")):
+                or item_object.startswith("RF")
+            ):
                 if item_object not in self.flags:
                     self.flags.append(item_object)
                 is_new_pseudoitem = True
             elif item_object in all_partners:
                 if item_object not in self.partners:
                     self.partners.append(item_object)
-                    self.item_history.append(item_object)
+                    self.item_history.append(f"+{item_object}")
                     is_new_pseudoitem = True
             elif item_object.find("StarPiece") != -1:
                 if item_object not in self.starpieces:
@@ -50,7 +51,7 @@ class Mario:
                     else:
                         self.starpiece_count += 1
                     self.starpieces.append(item_object)
-                    self.item_history.append(item_object)
+                    self.item_history.append(f"+{item_object}")
             elif item_object.startswith("FAVOR"):
                 if item_object not in self.favors:
                     self.favors.append(item_object)
@@ -73,7 +74,7 @@ class Mario:
             else:
                 if item_object not in self.items:
                     self.items.append(item_object)
-                    self.item_history.append(item_object)
+                    self.item_history.append(f"+{item_object}")
 
             #print(f"New item: {item_object}")
 
@@ -86,6 +87,54 @@ class Mario:
                 if is_new_pseudoitem:
                     has_new_pseudoitem = True
             return has_new_pseudoitem
+
+        raise TypeError('item_object argument is not of type str or list',
+                        type(item_object),
+                        item_object)
+
+
+    def remove_from_inventory(self, item_object):
+        """Remove something from Mario's inventory."""
+        all_partners = ["Goombario", "Kooper", "Bombette", "Parakarry",
+                        "Bow", "Watt", "Sushie", "Lakilester"]
+        # Overload: Single item -> Remove item
+        if isinstance(item_object, str):
+
+            if (   item_object.startswith("GF")
+                or item_object.startswith("MF")
+                or item_object.startswith("MB")
+                or item_object.startswith("RF")
+            ):
+                self.flags.remove(item_object)
+            elif item_object in all_partners:
+                self.partners.remove(item_object)
+                self.item_history.append(f"-{item_object}")
+            elif item_object.find("StarPiece") != -1:
+                if item_object.startswith("Three"):
+                    self.starpiece_count -= 3
+                else:
+                    self.starpiece_count -= 1
+                self.starpieces.remove(item_object)
+                self.item_history.append(f"-{item_object}")
+            elif item_object.startswith("FAVOR"):
+                self.favors.remove(item_object)
+            elif item_object.startswith("EQUIPMENT"):
+                if (item_object.startswith("EQUIPMENT_Boots_Progressive")):
+                    self.boots.remove(item_object)
+                if (item_object.startswith("EQUIPMENT_Hammer_Progressive")):
+                    self.hammer.remove(item_object)
+            elif item_object.startswith("STARSPIRIT"):
+                self.starspirits.remove(item_object)
+            else:
+                self.items.remove(item_object)
+                self.item_history.append(f"-{item_object}")
+            return
+
+        # Overload: List of items -> Call function per item
+        if isinstance(item_object, list):
+            for singular_item in item_object:
+                self.remove_from_inventory(singular_item)
+            return
 
         raise TypeError('item_object argument is not of type str or list',
                         type(item_object),
@@ -230,8 +279,6 @@ class Mario:
                             break
                     # Check panel flipping
                     if req == "can_flip_panels":
-                        print(req)
-                        print(self.can_flip_panels())
                         if self.can_flip_panels():
                             group_fulfilled = True
                             break
@@ -270,77 +317,3 @@ class Mario:
                 break
 
         return fulfilled
-
-
-#def require(**kwargs):
-#    def func(kwargs=kwargs):
-#        global mario
-#        # Sanity-checking kwargs
-#        for key in kwargs.keys():
-#            if key not in [
-#                "partner",
-#                "item",
-#                "starpieces",
-#                "hammer",
-#                "boots",
-#                "favor",
-#                "flag",
-#                "starspirits"
-#            ]:
-#                raise KeyError('Requirement kwargs is not valid', key)
-#
-#        # Partners
-#        partners = kwargs.get("partner")
-#        if not isinstance(partners, list):
-#            partners = [partners]
-#        for partner in partners:
-#            if partner in mario.partners:
-#                return True
-#        # Items
-#        if items := kwargs.get("item"):
-#            if not isinstance(items, list):
-#                items = [items]
-#            for item in items:
-#                if item in multiuse_progression_items:
-#                    have_any_req_item = True in (multi_item in mario.items
-#                                                 for multi_item in multiuse_progression_items.get(item))
-#                    if have_any_req_item:
-#                        # remove single multiuse item #TODO very janky, pls rework
-#                        for multi_item in multiuse_progression_items.get(item):
-#                            if multi_item in mario.items:
-#                                mario.items.remove(multi_item)
-#                                break
-#                        return True
-#                if item in mario.items:
-#                    return True
-#        # StarPieces
-#        starpieces = kwargs.get("starpieces")
-#        if starpieces is not None and get_starpiece_count() >= starpieces:
-#            return True
-#        # Hammer
-#        hammer = kwargs.get("hammer")
-#        if hammer is not None and len(mario.hammer) >= hammer:
-#            return True
-#        # Boots
-#        if boots := kwargs.get("boots"):
-#            if len(mario.boots) >= boots:
-#                return True
-#        # Koopa Koot Favors
-#        if favor := kwargs.get("favor"):
-#            if favor in mario.favors:
-#                return True
-#        # Flags
-#        if flags := kwargs.get("flag"):
-#            if not isinstance(flags, list):
-#                flags = [flags]
-#            for flag in flags:
-#                if flag in mario.flags:
-#                    return True
-#        # Star Spirits
-#        if starspirits := kwargs.get("starspirits"):
-#            if len(mario.starspirits) >= starspirits:
-#                return True
-#                
-#
-#        return False
-#    return func

--- a/rando_modules/simulate.py
+++ b/rando_modules/simulate.py
@@ -20,222 +20,325 @@ class Mario:
         self.flags = kwargs.get("flags", [])
         self.starspirits = kwargs.get("starspirits", [])
         self.item_history = []
+        self.starpiece_count = 0
 
 
-def add_to_inventory(item_object):
-    """Add something to Mario's inventory."""
-    all_partners = ["Goombario", "Kooper", "Bombette", "Parakarry",
-                    "Bow", "Watt", "Sushie", "Lakilester"]
-    global mario
-    # Overload: Single item -> Add item
-    if isinstance(item_object, str):
-        is_new_pseudoitem = False
-    
-        if (   item_object.startswith("GF")
-            or item_object.startswith("MF")
-            or item_object.startswith("MB")
-            or item_object.startswith("RF")):
-            if item_object not in mario.flags:
-                mario.flags.append(item_object)
-            is_new_pseudoitem = True
-        elif item_object in all_partners:
-            if item_object not in mario.partners:
-                mario.partners.append(item_object)
-                mario.item_history.append(item_object)
+    def add_to_inventory(self, item_object):
+        """Add something to Mario's inventory."""
+        all_partners = ["Goombario", "Kooper", "Bombette", "Parakarry",
+                        "Bow", "Watt", "Sushie", "Lakilester"]
+        # Overload: Single item -> Add item
+        if isinstance(item_object, str):
+            is_new_pseudoitem = False
+
+            if (   item_object.startswith("GF")
+                or item_object.startswith("MF")
+                or item_object.startswith("MB")
+                or item_object.startswith("RF")):
+                if item_object not in self.flags:
+                    self.flags.append(item_object)
                 is_new_pseudoitem = True
-        elif item_object.find("StarPiece") != -1:
-            if item_object not in mario.starpieces:
-                mario.starpieces.append(item_object)
-                mario.item_history.append(item_object)
-        elif item_object.startswith("FAVOR"):
-            if item_object not in mario.favors:
-                mario.favors.append(item_object)
+            elif item_object in all_partners:
+                if item_object not in self.partners:
+                    self.partners.append(item_object)
+                    self.item_history.append(item_object)
+                    is_new_pseudoitem = True
+            elif item_object.find("StarPiece") != -1:
+                if item_object not in self.starpieces:
+                    if item_object.startswith("Three"):
+                        self.starpiece_count += 3
+                    else:
+                        self.starpiece_count += 1
+                    self.starpieces.append(item_object)
+                    self.item_history.append(item_object)
+            elif item_object.startswith("FAVOR"):
+                if item_object not in self.favors:
+                    self.favors.append(item_object)
+                    is_new_pseudoitem = True
+            elif item_object.startswith("EQUIPMENT"):
+                if (item_object.startswith("EQUIPMENT_Boots_Progressive")
+                and item_object not in self.boots
+                ):
+                    self.boots.append(item_object)
+                    is_new_pseudoitem = True
+                if (item_object.startswith("EQUIPMENT_Hammer_Progressive")
+                and item_object not in self.hammer
+                ):
+                    self.hammer.append(item_object)
+                    is_new_pseudoitem = True
+            elif item_object.startswith("STARSPIRIT"):
+                if item_object not in self.starspirits:
+                    self.starspirits.append(item_object)
                 is_new_pseudoitem = True
-        elif item_object.startswith("EQUIPMENT"):
-            if (item_object.startswith("EQUIPMENT_Boots_Progressive")
-            and item_object not in mario.boots
-            ):
-                mario.boots.append(item_object)
-                is_new_pseudoitem = True
-            if (item_object.startswith("EQUIPMENT_Hammer_Progressive")
-            and item_object not in mario.hammer
-            ):
-                mario.hammer.append(item_object)
-                is_new_pseudoitem = True
-        elif item_object.startswith("STARSPIRIT"):
-            if item_object not in mario.starspirits:
-                mario.starspirits.append(item_object)
-            is_new_pseudoitem = True
-        else:
-            if item_object not in mario.items:
-                mario.items.append(item_object)
-                mario.item_history.append(item_object)
-        
-        #print(f"New item: {item_object}")
+            else:
+                if item_object not in self.items:
+                    self.items.append(item_object)
+                    self.item_history.append(item_object)
 
-        return is_new_pseudoitem
-    # Overload: List of items -> Call function per item
-    if isinstance(item_object, list):
-        has_new_pseudoitem = False
-        for singular_item in item_object:
-            is_new_pseudoitem = add_to_inventory(singular_item)
-            if is_new_pseudoitem:
-                has_new_pseudoitem = True
-        return has_new_pseudoitem
+            #print(f"New item: {item_object}")
 
-    raise TypeError('item_object argument is not of type str or list',
-                    type(item_object),
-                    item_object)
+            return is_new_pseudoitem
+        # Overload: List of items -> Call function per item
+        if isinstance(item_object, list):
+            has_new_pseudoitem = False
+            for singular_item in item_object:
+                is_new_pseudoitem = self.add_to_inventory(singular_item)
+                if is_new_pseudoitem:
+                    has_new_pseudoitem = True
+            return has_new_pseudoitem
+
+        raise TypeError('item_object argument is not of type str or list',
+                        type(item_object),
+                        item_object)
 
 
-def clear_inventory():
-    """Completely clear Mario's inventory."""
-    global mario
-    mario = Mario()
+    def can_flip_panels(self):
+        """
+        Checks if Mario can currently flip hidden panels:
+        * Superboots or better, or
+        * UltraHammer
+        """
+        return len(self.hammer) == 3 or len(self.boots) >= 2
 
 
-def get_item_history():
-    """"""
-    global mario
-    return mario.item_history
+    def can_shake_trees(self):
+        """
+        Checks if Mario can currently shake trees:
+        * Hammer or better, or
+        * Bombette
+        """
+        return len(self.hammer) - 1 >= 0 or "Bombette" in self.partners
 
 
-def can_flip_panels():
-    """
-    Checks if Mario can currently flip hidden panels:
-    * Superboots or better, or
-    * UltraHammer
-    """
-    global mario
-    return len(mario.hammer) == 3 or len(mario.boots) >= 2
+    def can_hit_grounded_blocks(self):
+        """Check if Mario is able to hit a block placed on the ground."""
+        return (
+            len(self.hammer) - 1 >= 0
+         or len(self.boots) >= 1
+         or "Kooper" in self.partners
+         or "Bombette" in self.partners
+        )
 
 
-def can_shake_trees():
-    """
-    Checks if Mario can currently shake trees:
-    * Hammer or better, or
-    * Bombette
-    """
-    global mario
-    return len(mario.hammer) >= 1 or "Bombette" in mario.partners
+    def can_see_hidden_blocks(self):
+        """Check if Mario can see hidden blocks."""
+        return (
+            "Watt" in self.partners
+         or "RF_HiddenBlocksVisible" in self.flags
+        )
 
 
-def has_item(item_str):
-    """Checks if Mario currently has a certain item."""
-    global mario
-    return item_str in mario.items
-
-
-def has_partner(partner_str):
-    """Checks if Mario currently has a certain partner."""
-    global mario
-    return partner_str in mario.partners
-
-
-def has_parakarry_3_letters():
-    """Checks if Mario has three or more different letters he can give to Parakarry."""
-    global mario
-    count = 0
-    for item_str in mario.items:
-        if item_str.startswith("Letter"):
-            count += 1
-            if count >= 3:
-                return True
-    return False
-
-
-def get_starpiece_count() -> int:
-    global mario
-    sp_count = 0
-    for starpiece_item in mario.starpieces:
-        if starpiece_item.startswith("Three"):
-            sp_count = sp_count + 3
-        else:
-            sp_count = sp_count + 1
-    return sp_count
-
-
-def saved_all_yoshikids():
-    """Checks if Mario has saved all 5 of the Yoshi Kids"""
-    global mario
-    count = 0
-    for flag_str in mario.flags:
-        if flag_str.startswith("RF_SavedYoshiKid"):
-            count += 1
-            if count >= 5:
-                return True
-    return False
-
-
-def require(**kwargs):
-    def func(kwargs=kwargs):
-        global mario
-        # Sanity-checking kwargs
-        for key in kwargs.keys():
-            if key not in [
-                "partner",
-                "item",
-                "starpieces",
-                "hammer",
-                "boots",
-                "favor",
-                "flag",
-                "starspirits"
-            ]:
-                raise KeyError('Requirement kwargs is not valid', key)
-
-        # Partners
-        partners = kwargs.get("partner")
-        if not isinstance(partners, list):
-            partners = [partners]
-        for partner in partners:
-            if partner in mario.partners:
-                return True
-        # Items
-        if items := kwargs.get("item"):
-            if not isinstance(items, list):
-                items = [items]
-            for item in items:
-                if item in multiuse_progression_items:
-                    have_any_req_item = True in (multi_item in mario.items
-                                                 for multi_item in multiuse_progression_items.get(item))
-                    if have_any_req_item:
-                        # remove single multiuse item #TODO very janky, pls rework
-                        for multi_item in multiuse_progression_items.get(item):
-                            if multi_item in mario.items:
-                                mario.items.remove(multi_item)
-                                break
-                        return True
-                if item in mario.items:
+    def has_parakarry_letters(self):
+        """Checks if Mario has three or more different letters he can give to Parakarry."""
+        count = 0
+        for item_str in self.items:
+            if item_str.startswith("Letter"):
+                count += 1
+                if count >= 3:
                     return True
-        # StarPieces
-        starpieces = kwargs.get("starpieces")
-        if starpieces is not None and get_starpiece_count() >= starpieces:
-            return True
-        # Hammer
-        hammer = kwargs.get("hammer")
-        if hammer is not None and len(mario.hammer) >= hammer:
-            return True
-        # Boots
-        if boots := kwargs.get("boots"):
-            if len(mario.boots) >= boots:
-                return True
-        # Koopa Koot Favors
-        if favor := kwargs.get("favor"):
-            if favor in mario.favors:
-                return True
-        # Flags
-        if flags := kwargs.get("flag"):
-            if not isinstance(flags, list):
-                flags = [flags]
-            for flag in flags:
-                if flag in mario.flags:
-                    return True
-        # Star Spirits
-        if starspirits := kwargs.get("starspirits"):
-            if len(mario.starspirits) >= starspirits:
-                return True
-                
-
         return False
-    return func
+
+
+    def saved_all_yoshikids(self):
+        """Checks if Mario has saved all 5 of the Yoshi Kids"""
+        count = 0
+        for flag_str in self.flags:
+            if flag_str.startswith("RF_SavedYoshiKid"):
+                count += 1
+                if count >= 5:
+                    return True
+        return False
+
+
+    def requirements_fulfilled(self, all_reqs:list):
+        all_partners = ["Goombario", "Kooper", "Bombette", "Parakarry",
+                        "Bow", "Watt", "Sushie", "Lakilester"]
+        fulfilled = True
+        # For the requirements to be fulfilled, all requirement groups have
+        # to be met. Each requirement group has to have at least one of its
+        # conditions met to count as fulfilled.
+        # This effectively ANDs all requirement groups, and ORs all conditions
+        # within a given requirement group.
+        for req_group in all_reqs:
+            assert(isinstance(req_group, list))
+            group_fulfilled = False
+            for req in req_group:
+                if isinstance(req, dict):
+                    # Check star spirits
+                    if ("starspirits" in req
+                    and len(self.starspirits) >= req["starspirits"]
+                    ):
+                        group_fulfilled = True
+                        break
+                    # Check star pieces
+                    if ("starpieces" in req
+                    and self.starpiece_count >= req["starpieces"]
+                    ):
+                        group_fulfilled = True
+                        break
+                    # Check keys
+                    for key_name, key_count in req.items():
+                        keys_acquired = 0
+                        for item in self.items:
+                            if item.startswith(key_name):
+                                keys_acquired += 1
+                        if keys_acquired >= key_count:
+                            group_fulfilled = True
+                            break
+                else:
+                    # Check boots
+                    if req.endswith("Boots"):
+                        if req == "UltraBoots":
+                            if len(self.boots) >= 2:
+                                group_fulfilled = True
+                                break
+                        elif req == "SuperBoots":
+                            if len(self.boots) >= 1:
+                                group_fulfilled = True
+                                break
+                    # Check hammer
+                    if req.endswith("Hammer"):
+                        if req == "UltraHammer":
+                            if len(self.hammer) - 1 >= 2:
+                                group_fulfilled = True
+                                break
+                        elif req == "SuperHammer":
+                            if len(self.hammer) - 1 >= 1:
+                                group_fulfilled = True
+                                break
+                        elif req == "Hammer":
+                            if len(self.hammer) - 1 >= 0:
+                                group_fulfilled = True
+                                break
+                    # Check partners
+                    if req in all_partners:
+                        if req in self.partners:
+                            group_fulfilled = True
+                            break
+                    # Check flags
+                    if (   req.startswith("GF")
+                        or req.startswith("MF")
+                        or req.startswith("MB")
+                        or req.startswith("RF")):
+                        if req in self.flags:
+                            group_fulfilled = True
+                            break
+                    # Check Koopa Koot favors
+                    if req.startswith("FAVOR"):
+                        if req in self.favors:
+                            group_fulfilled = True
+                            break
+                    # Check panel flipping
+                    if req == "can_flip_panels":
+                        if self.can_flip_panels():
+                            group_fulfilled = True
+                            break
+                    # Check tree shaking
+                    if req == "can_shake_trees":
+                        if self.can_shake_trees():
+                            group_fulfilled = True
+                            break
+                    # Check letters for Parakarry
+                    if req == "has_parakarry_letters":
+                        if self.has_parakarry_letters():
+                            group_fulfilled = True
+                            break
+                    # Check saved Yoshi kids
+                    if req == "saved_all_yoshikids":
+                        if self.saved_all_yoshikids():
+                            group_fulfilled = True
+                            break
+                    # Check hitting grounded blocks
+                    if req == "can_hit_grounded_blocks":
+                        if self.can_hit_grounded_blocks():
+                            group_fulfilled = True
+                            break
+                    # Check hidden blocks
+                    if req == "can_see_hidden_blocks":
+                        if self.can_see_hidden_blocks():
+                            group_fulfilled = True
+                            break
+                    # Check other items
+                    if req in self.items:
+                        group_fulfilled = True
+                        break
+
+            if not group_fulfilled:
+                fulfilled = False
+                break
+
+        return fulfilled
+
+
+#def require(**kwargs):
+#    def func(kwargs=kwargs):
+#        global mario
+#        # Sanity-checking kwargs
+#        for key in kwargs.keys():
+#            if key not in [
+#                "partner",
+#                "item",
+#                "starpieces",
+#                "hammer",
+#                "boots",
+#                "favor",
+#                "flag",
+#                "starspirits"
+#            ]:
+#                raise KeyError('Requirement kwargs is not valid', key)
+#
+#        # Partners
+#        partners = kwargs.get("partner")
+#        if not isinstance(partners, list):
+#            partners = [partners]
+#        for partner in partners:
+#            if partner in mario.partners:
+#                return True
+#        # Items
+#        if items := kwargs.get("item"):
+#            if not isinstance(items, list):
+#                items = [items]
+#            for item in items:
+#                if item in multiuse_progression_items:
+#                    have_any_req_item = True in (multi_item in mario.items
+#                                                 for multi_item in multiuse_progression_items.get(item))
+#                    if have_any_req_item:
+#                        # remove single multiuse item #TODO very janky, pls rework
+#                        for multi_item in multiuse_progression_items.get(item):
+#                            if multi_item in mario.items:
+#                                mario.items.remove(multi_item)
+#                                break
+#                        return True
+#                if item in mario.items:
+#                    return True
+#        # StarPieces
+#        starpieces = kwargs.get("starpieces")
+#        if starpieces is not None and get_starpiece_count() >= starpieces:
+#            return True
+#        # Hammer
+#        hammer = kwargs.get("hammer")
+#        if hammer is not None and len(mario.hammer) >= hammer:
+#            return True
+#        # Boots
+#        if boots := kwargs.get("boots"):
+#            if len(mario.boots) >= boots:
+#                return True
+#        # Koopa Koot Favors
+#        if favor := kwargs.get("favor"):
+#            if favor in mario.favors:
+#                return True
+#        # Flags
+#        if flags := kwargs.get("flag"):
+#            if not isinstance(flags, list):
+#                flags = [flags]
+#            for flag in flags:
+#                if flag in mario.flags:
+#                    return True
+#        # Star Spirits
+#        if starspirits := kwargs.get("starspirits"):
+#            if len(mario.starspirits) >= starspirits:
+#                return True
+#                
+#
+#        return False
+#    return func


### PR DESCRIPTION
This PR makes simulate's Mario class non-global and allows creating an instance of it to modify and carry around the code.

Additionally, the require-function was thrown out for a requirements_fulfilled function, so edge requirements no longer hold a function call within their dict, but a simpler list of lists of requirements. Using this new list an instance of the Mario class pass an edge's req to a requirements_fulfilled call to let the Mario instance decide if the inventory is sufficient to fulfill the edge's requirements. This not only makes the handling of this function a bit more simple, it also removes imports from the edge-files.

Furthermore, all edge-files that made use of the require function have been adjusted to the new list of lists system.
This change has been tested and debugged on a full-sanity seed setting on a set seed, comparing the item placement between the non-global-mario changes and the current dev branch, guaranteeing 100% parity with item-placement before and after the changes.

Oddly, these changes write a few additional lines into the spoiler log sphere section which were missing before.