### PR TITLE
Prevent softlocks from wasting a progression miscitem that was given in the starting items

### DIFF
--- a/metadata/itemlocation_replenish.py
+++ b/metadata/itemlocation_replenish.py
@@ -5,7 +5,7 @@ Thusly this list includes items sold by shops, items found in certain trees,
 bushes and crates, as well as the item traded by the hungry Yoshi and the final
 trade item from Rip Cheato.
 """
-replenishing_itemlocations = [
+replenishing_itemlocations = {
     "DRO_01/ShopItemA","DRO_01/ShopItemC","DRO_01/ShopItemF",
     "FLO_16/ItemB",
     "FLO_09/ItemA",
@@ -32,4 +32,4 @@ replenishing_itemlocations = [
     "OMO_01/ItemB","OMO_01/ItemC","OMO_01/ItemD","OMO_01/ItemE","OMO_01/ItemF",
     "SAM_02/ItemA","SAM_02/ShopItemA","SAM_02/ShopItemB","SAM_02/ShopItemC","SAM_02/ShopItemD","SAM_02/ShopItemE","SAM_02/ShopItemF",
     "SBK_56/Tree1_Drop1A","SBK_56/Tree2_Drop1A",
-]
+}

--- a/metadata/progression_items.py
+++ b/metadata/progression_items.py
@@ -111,7 +111,7 @@ progression_items = {
 }
     # 0x0078 ??
 
-progression_miscitems = [
+progression_miscitems = {
     "TastyTonic",  # 0x0089 (Koopa Koot) alternative: Lime,Lemon;BubbleBerry,Coconut
     "SleepySheep", # 0x008F (Koopa Koot)
     "LifeShroom",  # 0x0095 (Koopa Koot)
@@ -127,4 +127,4 @@ progression_miscitems = [
     "CakeMix",     # 0x00AA (Koopa Koot: +KoopaLeaf -> KookyCookie; LemonCandy for AntiGuy; Cake for Gourmet Guy)
     "Coconut",     # 0x00AC (Koopa Koot)
     "Cake",        # 0x00C1 (Gourmet Guy)
-]
+}

--- a/rando_modules/simulate.py
+++ b/rando_modules/simulate.py
@@ -4,6 +4,7 @@ This is required for checking randomization logic.
 """
 
 from metadata.partners_meta import all_partners
+from metadata.progression_items import progression_miscitems
 
 class Mario:
     """
@@ -23,7 +24,7 @@ class Mario:
         self.starpiece_count = 0
 
 
-    def add_to_inventory(self, item_object):
+    def add_to_inventory(self, item_object, is_replenishable):
         """Add something to Mario's inventory."""
         # Overload: Single item -> Add item
         if isinstance(item_object, str):
@@ -71,8 +72,9 @@ class Mario:
                 is_new_pseudoitem = True
             else:
                 if item_object not in self.items:
-                    self.items.add(item_object)
-                    self.item_history.append(f"+{item_object}")
+                    if is_replenishable or item_object not in progression_miscitems:
+                        self.items.add(item_object)
+                        self.item_history.append(f"+{item_object}")
 
             #print(f"New item: {item_object}")
 
@@ -81,7 +83,7 @@ class Mario:
         if isinstance(item_object, list):
             has_new_pseudoitem = False
             for singular_item in item_object:
-                is_new_pseudoitem = self.add_to_inventory(singular_item)
+                is_new_pseudoitem = self.add_to_inventory(singular_item, is_replenishable)
                 if is_new_pseudoitem:
                     has_new_pseudoitem = True
             return has_new_pseudoitem


### PR DESCRIPTION
Don't consider progression miscitems to be in logic when obtained from a non-replenishable source (in particular, starting items)