### PR TITLE
Hotfix: Hammerless Random start

### DIFF
--- a/optionset.py
+++ b/optionset.py
@@ -374,7 +374,7 @@ class OptionSet:
 
         # Blocks related
         if "ShuffleBlocks" in options_dict:
-            self.shuffle_blocks = options_dict.get("ShuffleBlocks")
+            self.shuffle_blocks = options_dict.get("ShuffleBlocks").get("value")
 
         # Moves and Badges
         if "RandomBadgesBP" in options_dict:

--- a/random_seed.py
+++ b/random_seed.py
@@ -128,7 +128,7 @@ class RandomSeed:
         #self.placed_items = get_alpha_prices(self.placed_items)
 
         # Randomize blocks if needed
-        self.placed_blocks = get_block_placement(self.rando_settings.shuffle_blocks["value"])
+        self.placed_blocks = get_block_placement(self.rando_settings.shuffle_blocks)
 
         # Randomize chapter difficulty / enemy stats if needed
         self.enemy_stats, self.chapter_changes = get_shuffled_chapter_difficulty(


### PR DESCRIPTION
Fix the case where Goomba Village is picked so the retry rerolls a different location