### PR TITLE
Random color not vanilla

### DIFF
--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 0
-MarioSprite      : 0
-GoombarioSetting : 0
-GoombarioSprite  : 0
-KooperSetting    : 0
-KooperSprite     : 0
-BombetteSetting  : 0
-BombetteSprite   : 0
-ParakarrySetting : 0
-ParakarrySprite  : 0
-BowSetting       : 0
-BowSprite        : 0
-WattSetting      : 0
-WattSprite       : 0
-SushieSetting    : 0
-SushieSprite     : 0
-#LakilesterSetting: 0 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 0
-EnemiesSetting   : 0
-NPCSetting       : 0
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 0
+MarioSprite          : 0
+GoombarioSetting     : 0
+GoombarioSprite      : 0
+KooperSetting        : 0
+KooperSprite         : 0
+BombetteSetting      : 0
+BombetteSprite       : 0
+ParakarrySetting     : 0
+ParakarrySprite      : 0
+BowSetting           : 0
+BowSprite            : 0
+WattSetting          : 0
+WattSprite           : 0
+SushieSetting        : 0
+SushieSprite         : 0
+#LakilesterSetting    : 0 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 0
+EnemiesSetting       : 0
+NPCSetting           : 0
 
 # Audio
 RandomPitch: false

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 0
 MarioSprite          : 0

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 0
-MarioSprite      : 0
-GoombarioSetting : 0
-GoombarioSprite  : 0
-KooperSetting    : 0
-KooperSprite     : 0
-BombetteSetting  : 0
-BombetteSprite   : 0
-ParakarrySetting : 0
-ParakarrySprite  : 0
-BowSetting       : 0
-BowSprite        : 0
-WattSetting      : 0
-WattSprite       : 0
-SushieSetting    : 0
-SushieSprite     : 0
-#LakilesterSetting: 0 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 0
-EnemiesSetting   : 0
-NPCSetting       : 0
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 0
+MarioSprite          : 0
+GoombarioSetting     : 0
+GoombarioSprite      : 0
+KooperSetting        : 0
+KooperSprite         : 0
+BombetteSetting      : 0
+BombetteSprite       : 0
+ParakarrySetting     : 0
+ParakarrySprite      : 0
+BowSetting           : 0
+BowSprite            : 0
+WattSetting          : 0
+WattSprite           : 0
+SushieSetting        : 0
+SushieSprite         : 0
+#LakilesterSetting    : 0 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 0
+EnemiesSetting       : 0
+NPCSetting           : 0
 
 # Audio
 RandomPitch: false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 0
 MarioSprite          : 0

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 0
-MarioSprite      : 0
-GoombarioSetting : 0
-GoombarioSprite  : 0
-KooperSetting    : 0
-KooperSprite     : 0
-BombetteSetting  : 0
-BombetteSprite   : 0
-ParakarrySetting : 0
-ParakarrySprite  : 0
-BowSetting       : 0
-BowSprite        : 0
-WattSetting      : 0
-WattSprite       : 0
-SushieSetting    : 0
-SushieSprite     : 0
-#LakilesterSetting: 0 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 0
-EnemiesSetting   : 0
-NPCSetting       : 0
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 0
+MarioSprite          : 0
+GoombarioSetting     : 0
+GoombarioSprite      : 0
+KooperSetting        : 0
+KooperSprite         : 0
+BombetteSetting      : 0
+BombetteSprite       : 0
+ParakarrySetting     : 0
+ParakarrySprite      : 0
+BowSetting           : 0
+BowSprite            : 0
+WattSetting          : 0
+WattSprite           : 0
+SushieSetting        : 0
+SushieSprite         : 0
+#LakilesterSetting    : 0 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 0
+EnemiesSetting       : 0
+NPCSetting           : 0
 
 # Audio
 RandomPitch: false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 0
 MarioSprite          : 0

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 0
-MarioSprite      : 0
-GoombarioSetting : 0
-GoombarioSprite  : 0
-KooperSetting    : 0
-KooperSprite     : 0
-BombetteSetting  : 0
-BombetteSprite   : 0
-ParakarrySetting : 0
-ParakarrySprite  : 0
-BowSetting       : 0
-BowSprite        : 0
-WattSetting      : 0
-WattSprite       : 0
-SushieSetting    : 0
-SushieSprite     : 0
-#LakilesterSetting: 0 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 0
-EnemiesSetting   : 0
-NPCSetting       : 0
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 0
+MarioSprite          : 0
+GoombarioSetting     : 0
+GoombarioSprite      : 0
+KooperSetting        : 0
+KooperSprite         : 0
+BombetteSetting      : 0
+BombetteSprite       : 0
+ParakarrySetting     : 0
+ParakarrySprite      : 0
+BowSetting           : 0
+BowSprite            : 0
+WattSetting          : 0
+WattSprite           : 0
+SushieSetting        : 0
+SushieSprite         : 0
+#LakilesterSetting    : 0 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 0
+EnemiesSetting       : 0
+NPCSetting           : 0
 
 # Audio
 RandomPitch: false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 0
 MarioSprite          : 0

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 0
-MarioSprite      : 0
-GoombarioSetting : 0
-GoombarioSprite  : 0
-KooperSetting    : 0
-KooperSprite     : 0
-BombetteSetting  : 0
-BombetteSprite   : 0
-ParakarrySetting : 0
-ParakarrySprite  : 0
-BowSetting       : 0
-BowSprite        : 0
-WattSetting      : 0
-WattSprite       : 0
-SushieSetting    : 0
-SushieSprite     : 0
-#LakilesterSetting: 0 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 0
-EnemiesSetting   : 0
-NPCSetting       : 0
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 0
+MarioSprite          : 0
+GoombarioSetting     : 0
+GoombarioSprite      : 0
+KooperSetting        : 0
+KooperSprite         : 0
+BombetteSetting      : 0
+BombetteSprite       : 0
+ParakarrySetting     : 0
+ParakarrySprite      : 0
+BowSetting           : 0
+BowSprite            : 0
+WattSetting          : 0
+WattSprite           : 0
+SushieSetting        : 0
+SushieSprite         : 0
+#LakilesterSetting    : 0 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 0
+EnemiesSetting       : 0
+NPCSetting           : 0
 
 # Audio
 RandomPitch: false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 0
 MarioSprite          : 0

--- a/presets/preset_StandardRace.yaml
+++ b/presets/preset_StandardRace.yaml
@@ -161,7 +161,7 @@ RandomText     : false
 # DEFAULT_PALETTE    : 0
 # SELECT_PALETTE     : 1 (only Mario and partners)
 # RANDOM_PICK        : 2
-# RANDOM_NOT_VANILLA : 3
+# RANDOM_PICK_NOT_VANILLA  : 3
 # ALWAYS_RANDOM      : 4
 MarioSetting         : 2
 MarioSprite          : 0

--- a/presets/preset_StandardRace.yaml
+++ b/presets/preset_StandardRace.yaml
@@ -158,31 +158,32 @@ RomanNumerals  : false
 RandomText     : false
 
 # "*Setting" values explanation:
-# DEFAULT_PALETTE: 0
-# SELECT_PALETTE : 1 (only Mario and partners)
-# RANDOM_PICK    : 2
-# ALWAYS_RANDOM  : 3
-MarioSetting     : 2
-MarioSprite      : 0
-GoombarioSetting : 2
-GoombarioSprite  : 0
-KooperSetting    : 2
-KooperSprite     : 0
-BombetteSetting  : 2
-BombetteSprite   : 0
-ParakarrySetting : 2
-ParakarrySprite  : 0
-BowSetting       : 2
-BowSprite        : 0
-WattSetting      : 2
-WattSprite       : 0
-SushieSetting    : 2
-SushieSprite     : 0
-#LakilesterSetting: 2 # NYI
-#LakilesterSprite : 0 # NYI
-BossesSetting    : 2
-EnemiesSetting   : 2
-NPCSetting       : 2
+# DEFAULT_PALETTE    : 0
+# SELECT_PALETTE     : 1 (only Mario and partners)
+# RANDOM_PICK        : 2
+# RANDOM_NOT_VANILLA : 3
+# ALWAYS_RANDOM      : 4
+MarioSetting         : 2
+MarioSprite          : 0
+GoombarioSetting     : 2
+GoombarioSprite      : 0
+KooperSetting        : 2
+KooperSprite         : 0
+BombetteSetting      : 2
+BombetteSprite       : 0
+ParakarrySetting     : 2
+ParakarrySprite      : 0
+BowSetting           : 2
+BowSprite            : 0
+WattSetting          : 2
+WattSprite           : 0
+SushieSetting        : 2
+SushieSprite         : 0
+#LakilesterSetting    : 2 # NYI
+#LakilesterSprite     : 0 # NYI
+BossesSetting        : 2
+EnemiesSetting       : 2
+NPCSetting           : 2
 
 # Audio
 RandomPitch: false

--- a/rando_enums/enum_options.py
+++ b/rando_enums/enum_options.py
@@ -72,7 +72,8 @@ class RandomPalettes(IntEnum):
     DEFAULT_PALETTE = 0
     SELECT_PALETTE = 1
     RANDOM_PICK = 2
-    ALWAYS_RANDOM = 3
+    RANDOM_PICK_NOT_VANILLA = 3
+    ALWAYS_RANDOM = 4
 
 @unique
 class MerlowRewardPricing(IntEnum):

--- a/rando_modules/random_palettes.py
+++ b/rando_modules/random_palettes.py
@@ -191,7 +191,7 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
         elif cur_setting == RandomPalettes.RANDOM_PICK:
             if cur_sprite_name == "Mario":
                 # Player sprite special case, see *
-                chosen_palette = random.randrange(abs(RANDOM_NOT_VANILLA - cur_setting - 1), palette_count)
+                chosen_palette = random.randrange(0, palette_count)
             else:
                 chosen_palette = random.randrange(0, palette_count + 1)
         elif cur_setting == RandomPalettes.ALWAYS_RANDOM:
@@ -229,7 +229,13 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
                 palette_count = palette_info.palette_count
                 if palette_info.sprite == "Peach":
                     # Player sprite special case, see *
-                    chosen_palette = random.randrange(abs(RANDOM_NOT_VANILLA - palette_settings.npc_setting - 1), palette_count)
+                    chosen_palette = random.randrange(0, palette_count)
+                else:
+                    chosen_palette = random.randrange(0, palette_count + 1)
+            elif palette_settings.npc_setting == RANDOM_PICK_NOT_VANILLA:
+                palette_count = palette_info.palette_count
+                if palette_info.sprite == "Peach":
+                    chosen_palette = random.randrange(1, palette_count)
                 else:
                     chosen_palette = random.randrange(0, palette_count + 1)
             elif palette_settings.npc_setting == RandomPalettes.ALWAYS_RANDOM:

--- a/rando_modules/random_palettes.py
+++ b/rando_modules/random_palettes.py
@@ -249,7 +249,7 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
                 if palette_info.sprite == "Peach":
                     chosen_palette = random.randrange(1, palette_count)
                 else:
-                    chosen_palette = random.randrange(0, palette_count + 1)
+                    chosen_palette = random.randrange(1, palette_count + 1)
             elif palette_settings.npc_setting == RandomPalettes.ALWAYS_RANDOM:
                 chosen_palette = PALETTEVALUE_ALWAYS_RANDOM
             else:

--- a/rando_modules/random_palettes.py
+++ b/rando_modules/random_palettes.py
@@ -191,7 +191,7 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
         elif cur_setting == RandomPalettes.RANDOM_PICK:
             if cur_sprite_name == "Mario":
                 # Player sprite special case, see *
-                chosen_palette = random.randrange(0, palette_count)
+                chosen_palette = random.randrange(abs(RANDOM_NOT_VANILLA - cur_setting - 1), palette_count)
             else:
                 chosen_palette = random.randrange(0, palette_count + 1)
         elif cur_setting == RandomPalettes.ALWAYS_RANDOM:
@@ -229,7 +229,7 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
                 palette_count = palette_info.palette_count
                 if palette_info.sprite == "Peach":
                     # Player sprite special case, see *
-                    chosen_palette = random.randrange(0, palette_count)
+                    chosen_palette = random.randrange(abs(RANDOM_NOT_VANILLA - palette_settings.npc_setting - 1), palette_count)
                 else:
                     chosen_palette = random.randrange(0, palette_count + 1)
             elif palette_settings.npc_setting == RandomPalettes.ALWAYS_RANDOM:

--- a/rando_modules/random_palettes.py
+++ b/rando_modules/random_palettes.py
@@ -194,6 +194,12 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
                 chosen_palette = random.randrange(0, palette_count)
             else:
                 chosen_palette = random.randrange(0, palette_count + 1)
+        elif cur_setting == RandomPalettes.RANDOM_PICK_NOT_VANILLA:
+            if cur_sprite_name == "Mario":
+                # Player sprite special case, see *
+                chosen_palette = random.randrange(1, palette_count)
+            else:
+                chosen_palette = random.randrange(1, palette_count + 1)
         elif cur_setting == RandomPalettes.ALWAYS_RANDOM:
             chosen_palette = PALETTEVALUE_ALWAYS_RANDOM
         else:
@@ -210,6 +216,9 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
             if palette_settings.bosses_setting == RandomPalettes.RANDOM_PICK:
                 palette_count = palette_info.palette_count
                 chosen_palette = random.randrange(0, palette_count + 1)
+            if palette_settings.bosses_setting == RandomPalettes.RANDOM_PICK_NOT_VANILLA:
+                palette_count = palette_info.palette_count
+                chosen_palette = random.randrange(1, palette_count + 1)
             elif palette_settings.bosses_setting == RandomPalettes.ALWAYS_RANDOM:
                 chosen_palette = PALETTEVALUE_ALWAYS_RANDOM
             else:
@@ -219,6 +228,9 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
             if palette_settings.enemies_setting == RandomPalettes.RANDOM_PICK:
                 palette_count = palette_info.palette_count
                 chosen_palette = random.randrange(0, palette_count + 1)
+            if palette_settings.enemies_setting == RandomPalettes.RANDOM_PICK_NOT_VANILLA:
+                palette_count = palette_info.palette_count
+                chosen_palette = random.randrange(1, palette_count + 1)
             elif palette_settings.enemies_setting == RandomPalettes.ALWAYS_RANDOM:
                 chosen_palette = PALETTEVALUE_ALWAYS_RANDOM
             else:
@@ -232,7 +244,7 @@ def get_randomized_palettes(palette_settings:PaletteOptionSet) -> list:
                     chosen_palette = random.randrange(0, palette_count)
                 else:
                     chosen_palette = random.randrange(0, palette_count + 1)
-            elif palette_settings.npc_setting == RANDOM_PICK_NOT_VANILLA:
+            elif palette_settings.npc_setting == RandomPalettes.RANDOM_PICK_NOT_VANILLA:
                 palette_count = palette_info.palette_count
                 if palette_info.sprite == "Peach":
                     chosen_palette = random.randrange(1, palette_count)


### PR DESCRIPTION
Very simple change to support random color selection but exclude the default palettes from the random pool.

Had to remake this because the github PR wasn't updating with new commits after a rebase.