### PR TITLE
fix: bias towards late gear in Full Gear Shuffle

### DIFF
--- a/rando_modules/logic.py
+++ b/rando_modules/logic.py
@@ -778,7 +778,8 @@ def _algo_assumed_fill(
                     dungeon_restricted_items[item] = dungeon
         pool_combined_progression_items.sort(key=lambda x: x.item_name in dungeon_restricted_items.keys())
 
-    pool_combined_progression_items.sort(key=lambda x: x.item_type == "GEAR")
+    if gear_shuffle_mode == GearShuffleMode.GEAR_LOCATION_SHUFFLE:
+        pool_combined_progression_items.sort(key=lambda x: x.item_type == "GEAR")
 
     while pool_combined_progression_items:
         item = pool_combined_progression_items.pop()


### PR DESCRIPTION
In Big Chest shuffle, gear is placed before other key items, because their placement is restricted to only big chest locations. This makes sense.

In full gear shuffle, gear is still placed before other items. I'm assuming this is unintentional because it means the logic can effectively place gear anywhere at all, and places everything else to compensate. (For example, with the existing code, starting in goomba village jumpless will in practice always give you Parakarry in the village, never boots.)