### PR TITLE
Implement Logic for Missing Glitches

### DIFF
--- a/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
+++ b/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
@@ -2,7 +2,7 @@
 This file represents edges of the world graph that have to be added
 for Glitched Logic: Ruins Stone Skip.
 """
-edges_pra_add_ruins_stone_skip= [
+edges_isk_add_ruins_stone_skip= [
     #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Hidden Stairway
     {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": ["Lakilester"], "mapchange": False},
 ]

--- a/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
+++ b/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
@@ -4,5 +4,5 @@ for Glitched Logic: Ruins Stone Skip.
 """
 edges_isk_add_ruins_stone_skip= [
     #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Hidden Stairway
-    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": ["Lakilester"], "mapchange": False},
+    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": [["Lakilester"], ["Boots"]], "mapchange": False},
 ]

--- a/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
+++ b/maps/graph_edges/glitched_logic/isk_ruins_stone_skip.py
@@ -1,0 +1,8 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: Ruins Stone Skip.
+"""
+edges_pra_add_ruins_stone_skip= [
+    #? Stone Puzzle Room Exit Left -> Stone Puzzle Room Exit Hidden Stairway
+    {"from": {"map": "ISK_11", "id": 0}, "to": {"map": "ISK_11", "id": 3}, "reqs": ["Lakilester"], "mapchange": False},
+]

--- a/maps/graph_edges/glitched_logic/jan_kzn_ch5_sushie_glitch.py
+++ b/maps/graph_edges/glitched_logic/jan_kzn_ch5_sushie_glitch.py
@@ -28,10 +28,17 @@ edges_jan_kzn_add_ch5_sushie_glitch = [
     {"from": {"map": "KZN_08", "id": 0}, "to": {"map": "KZN_08", "id": "ChestA"}, "reqs": [["RF_Ch5_SushieGlitch"], ["can_climb_steps"]], "mapchange": False},
 ]
 
-edges_kzn_add_volcano_sushie_glitch = [
+edges_kzn_add_volcano_sushie_glitch_goombario = [
+    #? Central Cavern Exit West Upper -> Central Cavern Exit East Upper
+    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Sushie"], ["Goombario"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
+]
+
+edges_kzn_add_volcano_sushie_glitch_superboots = [
     #? Central Cavern Exit West Upper -> Central Cavern Exit East Upper
     {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Sushie"], ["Goombario", "Kooper", "Bombette"], ["SuperBoots"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
+]
 
+edges_kzn_add_volcano_sushie_glitch = [
     #? Flowing Lava Puzzle Exit East Upper -> Flowing Lava Puzzle Exit West
     {"from": {"map": "KZN_06", "id": 0}, "to": {"map": "KZN_06", "id": 1}, "reqs": [["RF_Volcano_SushieGlitch"]], "mapchange": False},
     #? Flowing Lava Puzzle Exit West -> Flowing Lava Puzzle Exit East Upper

--- a/maps/graph_edges/glitched_logic/jan_kzn_ch5_sushie_glitch.py
+++ b/maps/graph_edges/glitched_logic/jan_kzn_ch5_sushie_glitch.py
@@ -30,12 +30,12 @@ edges_jan_kzn_add_ch5_sushie_glitch = [
 
 edges_kzn_add_volcano_sushie_glitch_goombario = [
     #? Central Cavern Exit West Upper -> Central Cavern Exit East Upper
-    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Sushie"], ["Goombario"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
+    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Goombario"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
 ]
 
 edges_kzn_add_volcano_sushie_glitch_superboots = [
     #? Central Cavern Exit West Upper -> Central Cavern Exit East Upper
-    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Sushie"], ["Goombario", "Kooper", "Bombette"], ["SuperBoots"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
+    {"from": {"map": "KZN_03", "id": 0}, "to": {"map": "KZN_03", "id": 1}, "reqs": [["Goombario", "Kooper", "Bombette"], ["SuperBoots"], ["can_end_sushie_glitch"]], "pseudoitems": ["RF_Volcano_SushieGlitch"], "mapchange": False},
 ]
 
 edges_kzn_add_volcano_sushie_glitch = [

--- a/maps/graph_edges/glitched_logic/kmr_prologue_gel_early.py
+++ b/maps/graph_edges/glitched_logic/kmr_prologue_gel_early.py
@@ -4,5 +4,5 @@ for Glitched Logic: Prologue Gel Early.
 """
 edges_kmr_add_prologue_gel_early = [
     #* Bottom of the Cliff Exit Right -> HiddenYBlockA (RepelGel)
-    {"from": {"map": "KMR_03", "id": 1}, "to": {"map": "KMR_03", "id": "HiddenYBlockA"}, "reqs": [["Kooper", "Bombette"],["Boots"]], "mapchange": False}
+    {"from": {"map": "KMR_03", "id": 1}, "to": {"map": "KMR_03", "id": "HiddenYBlockA"}, "reqs": [["Kooper", "Bombette", "Parakarry", "Lakilester"],["Boots"]], "mapchange": False}
 ]

--- a/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
+++ b/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
@@ -4,5 +4,5 @@ for Glitched Logic: Clippy Green Station Coin Block.
 """
 edges_omo_clippy_green_station_coin_block = [
     #* GRN Treadmills/Slot Machine -> RandomBlockItemA (MultiCoinBlock)
-    (0xA1100840, {"from": {"map": "OMO_09", "id": "ItemH"}, "to": {"map": "OMO_09", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False})
+    (0xA1100840, {"from": {"map": "OMO_09", "id": "ItemH"}, "to": {"map": "OMO_09", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"]], "mapchange": False})
 ]

--- a/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
+++ b/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
@@ -1,0 +1,8 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: Clippy Green Station Coin Block.
+"""
+edges_omo_clippy_green_station_coin_block = [
+    #* GRN Treadmills/Slot Machine -> RandomBlockItemA (MultiCoinBlock)
+    {0xA1100840, "from": {"map": "OMO_09", "id": "ItemH"}, "to": {"map": "OMO_09", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
+]

--- a/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
+++ b/maps/graph_edges/glitched_logic/omo_clippy_green_station_coin_block.py
@@ -4,5 +4,5 @@ for Glitched Logic: Clippy Green Station Coin Block.
 """
 edges_omo_clippy_green_station_coin_block = [
     #* GRN Treadmills/Slot Machine -> RandomBlockItemA (MultiCoinBlock)
-    {0xA1100840, "from": {"map": "OMO_09", "id": "ItemH"}, "to": {"map": "OMO_09", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
+    (0xA1100840, {"from": {"map": "OMO_09", "id": "ItemH"}, "to": {"map": "OMO_09", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False})
 ]

--- a/maps/graph_edges/glitched_logic/omo_wattless_dark_room.py
+++ b/maps/graph_edges/glitched_logic/omo_wattless_dark_room.py
@@ -1,6 +1,6 @@
 """
 This file represents edges of the world graph that have to be added
-for Glitched Logic: ToyBox Blue Switch Skip.
+for Glitched Logic: Wattless Dark Room.
 """
 edges_omo_add_wattless_dark_room = [
     # RED Boss Antechamber Exit East -> RED General Guy Room Exit West

--- a/maps/graph_edges/glitched_logic/omo_wattless_dark_room.py
+++ b/maps/graph_edges/glitched_logic/omo_wattless_dark_room.py
@@ -1,0 +1,8 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: ToyBox Blue Switch Skip.
+"""
+edges_omo_add_wattless_dark_room = [
+    # RED Boss Antechamber Exit East -> RED General Guy Room Exit West
+    {"from": {"map": "OMO_14", "id": 1}, "to": {"map": "OMO_15", "id": 0}, "reqs": [["Lakilester"]], "mapchange": True},
+]

--- a/maps/graph_edges/glitched_logic/pra_kooper_puzzle_skip.py
+++ b/maps/graph_edges/glitched_logic/pra_kooper_puzzle_skip.py
@@ -4,5 +4,5 @@ for Glitched Logic: Kooper Puzzle Skip
 """
 edges_pra_add_kooper_puzzle_skip= [
     # Reflection Mimic Room Bombable Wall -> Mirrored Door Room Bombable Wall
-    {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_20", "id": 0}, "reqs": ["Kooper"], "mapchange": True},
+    {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_20", "id": 0}, "reqs": [["Kooper"]], "mapchange": True},
 ]

--- a/maps/graph_edges/glitched_logic/pra_kooper_puzzle_skip.py
+++ b/maps/graph_edges/glitched_logic/pra_kooper_puzzle_skip.py
@@ -1,0 +1,8 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: Kooper Puzzle Skip
+"""
+edges_pra_add_kooper_puzzle_skip= [
+    # Reflection Mimic Room Bombable Wall -> Mirrored Door Room Bombable Wall
+    {"from": {"map": "PRA_19", "id": 1}, "to": {"map": "PRA_20", "id": 0}, "reqs": ["Kooper"], "mapchange": True},
+]

--- a/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
+++ b/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
@@ -3,12 +3,6 @@ This file represents edges of the world graph that have to be added
 for Glitched Logic: Chapter 7 Bridge with Super Boots.
 """
 edges_tik_add_chapter_7_bridge_with_super_boots = [
-    #* Hidden Blocks Room (B2) Exit Left -> YBlockB (Coin)
-    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockB"}, "reqs": [["SuperBoots"]], "mapchange": False},
-    #* Hidden Blocks Room (B2) Exit Left -> YBlockC (Coin)
-    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockC"}, "reqs": [["SuperBoots"]], "mapchange": False},
-    #* Hidden Blocks Room (B2) Exit Left -> YBlockD (Coin)
-    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockD"}, "reqs": [["SuperBoots"]], "mapchange": False},
-    #* Hidden Blocks Room (B2) Exit Left -> YBlockE (Coin)
-    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockE"}, "reqs": [["SuperBoots"]], "mapchange": False},
+    #+ Make hidden block bridge
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "0"}, "reqs": [["SuperBoots"],["can_see_hidden_blocks"]], "pseudoitems": ["RF_BuiltCh7Bridge"], "mapchange": False}
 ]

--- a/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
+++ b/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
@@ -4,5 +4,5 @@ for Glitched Logic: Chapter 7 Bridge with Super Boots.
 """
 edges_tik_add_chapter_7_bridge_with_super_boots = [
     #+ Make hidden block bridge
-    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "0"}, "reqs": [["SuperBoots"],["can_see_hidden_blocks"]], "pseudoitems": ["RF_BuiltCh7Bridge"], "mapchange": False}
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": 0}, "reqs": [["SuperBoots"],["can_see_hidden_blocks"]], "pseudoitems": ["RF_BuiltCh7Bridge"], "mapchange": False}
 ]

--- a/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
+++ b/maps/graph_edges/glitched_logic/tik_chapter_7_bridge_with_super_boots.py
@@ -1,0 +1,14 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: Chapter 7 Bridge with Super Boots.
+"""
+edges_tik_add_chapter_7_bridge_with_super_boots = [
+    #* Hidden Blocks Room (B2) Exit Left -> YBlockB (Coin)
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockB"}, "reqs": [["SuperBoots"]], "mapchange": False},
+    #* Hidden Blocks Room (B2) Exit Left -> YBlockC (Coin)
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockC"}, "reqs": [["SuperBoots"]], "mapchange": False},
+    #* Hidden Blocks Room (B2) Exit Left -> YBlockD (Coin)
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockD"}, "reqs": [["SuperBoots"]], "mapchange": False},
+    #* Hidden Blocks Room (B2) Exit Left -> YBlockE (Coin)
+    {"from": {"map": "TIK_21", "id": 0}, "to": {"map": "TIK_21", "id": "YBlockE"}, "reqs": [["SuperBoots"]], "mapchange": False},
+]

--- a/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
+++ b/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
@@ -4,5 +4,5 @@ for Glitched Logic: Clippy Sewers Upgrade Block.
 """
 edges_tik_add_clippy_sewers_upgrade_block = [
     #* Metal Block Room (B3) -> RandomBlockItemA (SuperBlock)
-    {0xA1020A40, "from": {"map": "TIK_12", "id": 0}, "to": {"map": "TIK_12", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
+    (0xA1020A40, {"from": {"map": "TIK_12", "id": 0}, "to": {"map": "TIK_12", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False})
 ]

--- a/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
+++ b/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
@@ -4,5 +4,5 @@ for Glitched Logic: Clippy Sewers Upgrade Block.
 """
 edges_tik_add_clippy_sewers_upgrade_block = [
     #* Metal Block Room (B3) -> RandomBlockItemA (SuperBlock)
-    {"from": {"map": "TIK_12", "id": 0}, "to": {"map": "TIK_12", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
+    {0xA1020A40, "from": {"map": "TIK_12", "id": 0}, "to": {"map": "TIK_12", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
 ]

--- a/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
+++ b/maps/graph_edges/glitched_logic/tik_clippy_sewers_upgrade_block.py
@@ -1,0 +1,8 @@
+"""
+This file represents edges of the world graph that have to be added
+for Glitched Logic: Clippy Sewers Upgrade Block.
+"""
+edges_tik_add_clippy_sewers_upgrade_block = [
+    #* Metal Block Room (B3) -> RandomBlockItemA (SuperBlock)
+    {"from": {"map": "TIK_12", "id": 0}, "to": {"map": "TIK_12", "id": "RandomBlockItemA"}, "reqs": [["Lakilester"],["Boots"]], "mapchange": False},
+]

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -67,6 +67,7 @@ class GlitchOptionSet():
         self.parakarryless_super_hammer_room_ultra_boots = False
         self.parakarryless_super_hammer_room_normal_boots = False
         self.ruins_locks_skip_clippy = False
+        self.ruins_stone_skip = False
 
         self.forever_forest_backwards = False
 
@@ -101,6 +102,7 @@ class GlitchOptionSet():
         self.blue_switch_skip_laki = False
         self.blue_switch_skip_ultra_boots = False
         self.red_barricade_skip = False
+        self.wattless_dark_room = False
         self.hammerless_blue_station_laki = False
         self.hammerless_pink_station_laki = False
 

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -115,7 +115,8 @@ class GlitchOptionSet():
         self.ultra_hammer_skip_sushie = False
         self.flarakarry = False
         self.parakarryless_flarakarry_laki = False
-        self.volcano_sushie_glitch = False
+        self.volcano_sushie_glitch_superboots = False
+        self.volcano_sushie_glitch_goombario = False
 
         self.early_laki_lzs = False
         self.early_laki_bombette_push = False

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -28,6 +28,7 @@ class GlitchOptionSet():
         self.island_pipe_blooper_skip = False
         self.parakarryless_sewer_star_piece = False
         self.sewer_blocks_without_ultra_boots = False
+        self.chapter_7_bridge_with_super_boots = False
         self.first_block_to_shiver_city_without_super_boots = False
         self.blocks_to_shiver_city_kooper_shell_item_throw = False
         self.sewer_yellow_block_with_ultra_boots = False

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -146,6 +146,7 @@ class GlitchOptionSet():
         self.sushieless_warehouse_key_kooper = False
 
         self.mirror_clip = False
+        self.kooper_puzzle_skip = False
 
         self.bowless_bowsers_castle_basement = False
         self.fast_flood_room_kooper = False

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -27,6 +27,7 @@ class GlitchOptionSet():
         self.clippy_boots_metal_block_skip = False
         self.island_pipe_blooper_skip = False
         self.parakarryless_sewer_star_piece = False
+        self.clippy_sewers_upgrade_block = False
         self.sewer_blocks_without_ultra_boots = False
         self.chapter_7_bridge_with_super_boots = False
         self.first_block_to_shiver_city_without_super_boots = False

--- a/models/options/GlitchOptionSet.py
+++ b/models/options/GlitchOptionSet.py
@@ -96,6 +96,7 @@ class GlitchOptionSet():
         self.gourmet_guy_skip_laki = False
         self.gourmet_guy_skip_parakarry = False
         self.bowless_green_station = False
+        self.clippy_green_station_coin_block = False
         self.kooperless_red_station_shooting_star = False
         self.gearless_red_station_shooting_star = False
         self.parakarryless_blue_block_city_gap = False

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -921,7 +921,9 @@ class OptionSet:
         if "ParakarrylessFlarakarryLaki" in options_dict:
             self.glitch_settings.parakarryless_flarakarry_laki = options_dict.get("ParakarrylessFlarakarryLaki")
         if "VolcanoSushieGlitch" in options_dict:
-            self.glitch_settings.volcano_sushie_glitch = options_dict.get("VolcanoSushieGlitch")
+            self.glitch_settings.volcano_sushie_glitch_superboots = options_dict.get("VolcanoSushieGlitch")
+        if "VolcanoSushieGlitchGoombario" in options_dict:
+            self.glitch_settings.volcano_sushie_glitch_goombario = options_dict.get("VolcanoSushieGlitchGoombario")
 
         if "EarlyLakiLZS" in options_dict:
             self.glitch_settings.early_laki_lzs = options_dict.get("EarlyLakiLZS")
@@ -2006,7 +2008,7 @@ class OptionSet:
         web_settings["UltraHammerSkipSushie"] = self.glitch_settings.ultra_hammer_skip_sushie
         web_settings["Flarakarry"] = self.glitch_settings.flarakarry
         web_settings["ParakarrylessFlarakarryLaki"] = self.glitch_settings.parakarryless_flarakarry_laki
-        web_settings["VolcanoSushieGlitch"] = self.glitch_settings.volcano_sushie_glitch
+        web_settings["VolcanoSushieGlitch"] = self.glitch_settings.volcano_sushie_glitch_superboots
 
         # Glitches: Flower Fields
         web_settings["EarlyLakiLZS"] = self.glitch_settings.early_laki_lzs

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -829,6 +829,8 @@ class OptionSet:
             self.glitch_settings.parakarryless_super_hammer_room_normal_boots = options_dict.get("ParakarrylessSuperHammerRoomNormalBoots")
         if "RuinsLocksSkipClippy" in options_dict:
             self.glitch_settings.ruins_locks_skip_clippy = options_dict.get("RuinsLocksSkipClippy")
+        if "RuinsStoneSkip" in options_dict:
+            self.glitch_settings.ruins_stone_skip = options_dict.get("RuinsStoneSkip")
 
         if "ForeverForestBackwards" in options_dict:
             self.glitch_settings.forever_forest_backwards = options_dict.get("ForeverForestBackwards")
@@ -1438,6 +1440,7 @@ class OptionSet:
         basic_assert("ParakarrylessSuperHammerRoomUltraBoots", bool)
         basic_assert("ParakarrylessSuperHammerRoomNormalBoots", bool)
         basic_assert("RuinsLocksSkipClippy", bool)
+        basic_assert("RuinsStoneSkip", bool)
 
         basic_assert("ForeverForestBackwards", bool)
 
@@ -1964,6 +1967,7 @@ class OptionSet:
         web_settings["ParakarrylessSuperHammerRoomUltraBoots"] = self.glitch_settings.parakarryless_super_hammer_room_ultra_boots
         web_settings["ParakarrylessSuperHammerRoomNormalBoots"] = self.glitch_settings.parakarryless_super_hammer_room_normal_boots
         web_settings["RuinsLocksSkipClippy"] = self.glitch_settings.ruins_locks_skip_clippy
+        web_settings["RuinsStoneSkip"] = self.glitch_settings.ruins_stone_skip
 
         # Glitches: Boo's Mansion
         web_settings["ForeverForestBackwards"] = self.glitch_settings.forever_forest_backwards

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -894,6 +894,8 @@ class OptionSet:
             self.glitch_settings.blue_switch_skip_ultra_boots = options_dict.get("BlueSwitchSkipUltraBoots")
         if "RedBarricadeSkip" in options_dict:
             self.glitch_settings.red_barricade_skip = options_dict.get("RedBarricadeSkip")
+        if "WattlessDarkRoom" in options_dict:
+            self.glitch_settings.wattless_dark_room = options_dict.get("WattlessDarkRoom")
         if "HammerlessBlueStationLaki" in options_dict:
             self.glitch_settings.hammerless_blue_station_laki = options_dict.get("HammerlessBlueStationLaki")
         if "HammerlessPinkStationLaki" in options_dict:
@@ -1475,6 +1477,7 @@ class OptionSet:
         basic_assert("BlueSwitchSkipLaki", bool)
         basic_assert("BlueSwitchSkipUltraBoots", bool)
         basic_assert("RedBarricadeSkip", bool)
+        basic_assert("WattlessDarkRoom", bool)
         basic_assert("HammerlessBlueStationLaki", bool)
         basic_assert("HammerlessPinkStationLaki", bool)
 
@@ -2005,6 +2008,7 @@ class OptionSet:
         web_settings["BlueSwitchSkipLaki"] = self.glitch_settings.blue_switch_skip_laki
         web_settings["BlueSwitchSkipUltraBoots"] = self.glitch_settings.blue_switch_skip_ultra_boots
         web_settings["RedBarricadeSkip"] = self.glitch_settings.red_barricade_skip
+        web_settings["WattlessDarkRoom"] = self.glitch_settings.wattless_dark_room
         web_settings["HammerlessBlueStationLaki"] = self.glitch_settings.hammerless_blue_station_laki
         web_settings["HammerlessPinkStationLaki"] = self.glitch_settings.hammerless_pink_station_laki
 

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -882,6 +882,8 @@ class OptionSet:
             self.glitch_settings.gourmet_guy_skip_parakarry = options_dict.get("GourmetGuySkipParakarry")
         if "BowlessGreenStation" in options_dict:
             self.glitch_settings.bowless_green_station = options_dict.get("BowlessGreenStation")
+        if "ClippyGreenStationCoinBlock" in options_dict:
+            self.glitch_settings.clippy_green_station_coin_block = options_dict.get("ClippyGreenStationCoinBlock")
         if "KooperlessRedStationShootingStar" in options_dict:
             self.glitch_settings.kooperless_red_station_shooting_star = options_dict.get("KooperlessRedStationShootingStar")
         if "GearlessRedStationShootingStar" in options_dict:
@@ -1471,6 +1473,7 @@ class OptionSet:
         basic_assert("GourmetGuySkipLaki", bool)
         basic_assert("GourmetGuySkipParakarry", bool)
         basic_assert("BowlessGreenStation", bool)
+        basic_assert("ClippyGreenStationCoinBlock", bool)
         basic_assert("KooperlessRedStationShootingStar", bool)
         basic_assert("GearlessRedStationShootingStar", bool)
         basic_assert("ParakarrylessBlueBlockCityGap", bool)
@@ -2002,6 +2005,7 @@ class OptionSet:
         web_settings["GourmetGuySkipLaki"] = self.glitch_settings.gourmet_guy_skip_laki
         web_settings["GourmetGuySkipParakarry"] = self.glitch_settings.gourmet_guy_skip_parakarry
         web_settings["BowlessGreenStation"] = self.glitch_settings.bowless_green_station
+        web_settings["ClippyGreenStationCoinBlock"] = self.glitch_settings.clippy_green_station_coin_block
         web_settings["KooperlessRedStationShootingStar"] = self.glitch_settings.kooperless_red_station_shooting_star
         web_settings["GearlessRedStationShootingStar"] = self.glitch_settings.gearless_red_station_shooting_star
         web_settings["ParakarrylessBlueBlockCityGap"] = self.glitch_settings.parakarryless_blue_block_city_gap

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -754,6 +754,8 @@ class OptionSet:
             self.glitch_settings.parakarryless_sewer_star_piece = options_dict.get("ParakarrylessSewerStarPiece")
         if "SewerBlocksWithoutUltraBoots" in options_dict:
             self.glitch_settings.sewer_blocks_without_ultra_boots = options_dict.get("SewerBlocksWithoutUltraBoots")
+        if "Chapter7BridgeWithSuperBoots" in options_dict:
+            self.glitch_settings.chapter_7_bridge_with_super_boots = options_dict.get("Chapter7BridgeWithSuperBoots")
         if "FirstBlockToShiverCityWithoutSuperBoots" in options_dict:
             self.glitch_settings.first_block_to_shiver_city_without_super_boots = options_dict.get("FirstBlockToShiverCityWithoutSuperBoots")
         if "BlocksToShiverCityWithKooperShellItemThrow" in options_dict:
@@ -1909,6 +1911,7 @@ class OptionSet:
         web_settings["IslandPipeBlooperSkip"] = self.glitch_settings.island_pipe_blooper_skip
         web_settings["ParakarrylessSewerStarPiece"] = self.glitch_settings.parakarryless_sewer_star_piece
         web_settings["SewerBlocksWithoutUltraBoots"] = self.glitch_settings.sewer_blocks_without_ultra_boots
+        web_settings["Chapter7BridgeWithSuperBoots"] = self.glitch_settings.chapter_7_bridge_with_super_boots
         web_settings["FirstBlockToShiverCityWithoutSuperBoots"] = self.glitch_settings.first_block_to_shiver_city_without_super_boots
         web_settings["BlocksToShiverCityWithKooperShellItemThrow"] = self.glitch_settings.blocks_to_shiver_city_kooper_shell_item_throw
         web_settings["SewerYellowBlockWithUltraBoots"] = self.glitch_settings.sewer_yellow_block_with_ultra_boots
@@ -2009,6 +2012,7 @@ class OptionSet:
         web_settings["Flarakarry"] = self.glitch_settings.flarakarry
         web_settings["ParakarrylessFlarakarryLaki"] = self.glitch_settings.parakarryless_flarakarry_laki
         web_settings["VolcanoSushieGlitch"] = self.glitch_settings.volcano_sushie_glitch_superboots
+        web_settings["VolcanoSushieGlitchGoombario"] = self.glitch_settings.volcano_sushie_glitch_goombario
 
         # Glitches: Flower Fields
         web_settings["EarlyLakiLZS"] = self.glitch_settings.early_laki_lzs

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -752,6 +752,8 @@ class OptionSet:
             self.glitch_settings.island_pipe_blooper_skip = options_dict.get("IslandPipeBlooperSkip")
         if "ParakarrylessSewerStarPiece" in options_dict:
             self.glitch_settings.parakarryless_sewer_star_piece = options_dict.get("ParakarrylessSewerStarPiece")
+        if "ClippySewersUpgradeBlock" in options_dict:
+            self.glitch_settings.clippy_sewers_upgrade_block = options_dict.get("ClippySewersUpgradeBlock")
         if "SewerBlocksWithoutUltraBoots" in options_dict:
             self.glitch_settings.sewer_blocks_without_ultra_boots = options_dict.get("SewerBlocksWithoutUltraBoots")
         if "Chapter7BridgeWithSuperBoots" in options_dict:
@@ -1393,7 +1395,9 @@ class OptionSet:
         basic_assert("ClippyBootsMetalBlockSkip", bool)
         basic_assert("IslandPipeBlooperSkip", bool)
         basic_assert("ParakarrylessSewerStarPiece", bool)
+        basic_assert("ClippySewersUpgradeBlock", bool)
         basic_assert("SewerBlocksWithoutUltraBoots", bool)
+        basic_assert("Chapter7BridgeWithSuperBoots", bool)
         basic_assert("FirstBlockToShiverCityWithoutSuperBoots", bool)
         basic_assert("BlocksToShiverCityWithKooperShellItemThrow", bool)
         basic_assert("SewerYellowBlockWithUltraBoots", bool)
@@ -1484,6 +1488,7 @@ class OptionSet:
         basic_assert("Flarakarry", bool)
         basic_assert("ParakarrylessFlarakarryLaki", bool)
         basic_assert("VolcanoSushieGlitch", bool)
+        basic_assert("VolcanoSushieGlitchGoombario", bool)
 
         basic_assert("EarlyLakiLZS", bool)
         basic_assert("EarlyLakiBombettePush", bool)
@@ -1910,6 +1915,7 @@ class OptionSet:
         web_settings["ClippyBootsMetalBlockSkip"] = self.glitch_settings.clippy_boots_metal_block_skip
         web_settings["IslandPipeBlooperSkip"] = self.glitch_settings.island_pipe_blooper_skip
         web_settings["ParakarrylessSewerStarPiece"] = self.glitch_settings.parakarryless_sewer_star_piece
+        web_settings["ClippySewersUpgradeBlock"] = self.glitch_settings.clippy_sewers_upgrade_block
         web_settings["SewerBlocksWithoutUltraBoots"] = self.glitch_settings.sewer_blocks_without_ultra_boots
         web_settings["Chapter7BridgeWithSuperBoots"] = self.glitch_settings.chapter_7_bridge_with_super_boots
         web_settings["FirstBlockToShiverCityWithoutSuperBoots"] = self.glitch_settings.first_block_to_shiver_city_without_super_boots

--- a/models/options/OptionSet.py
+++ b/models/options/OptionSet.py
@@ -979,6 +979,8 @@ class OptionSet:
 
         if "MirrorClip" in options_dict:
             self.glitch_settings.mirror_clip = options_dict.get("MirrorClip")
+        if "KooperPuzzleSkip" in options_dict:
+            self.glitch_settings.kooper_puzzle_skip = options_dict.get("KooperPuzzleSkip")
 
         if "BowlessBowsersCastleBasement" in options_dict:
             self.glitch_settings.bowless_bowsers_castle_basement = options_dict.get("BowlessBowsersCastleBasement")
@@ -1516,6 +1518,7 @@ class OptionSet:
         basic_assert("SushielessWarehouseKeyKooper", bool)
 
         basic_assert("MirrorClip", bool)
+        basic_assert("KooperPuzzleSkip", bool)
 
         basic_assert("BowlessBowsersCastleBasement", bool)
         basic_assert("FastFloodRoomKooper", bool)
@@ -2049,6 +2052,7 @@ class OptionSet:
 
         # Glitches: Crystal Palace
         web_settings["MirrorClip"] = self.glitch_settings.mirror_clip
+        web_settings["KooperPuzzleSkip"] = self.glitch_settings.kooper_puzzle_skip
 
         # Glitches: Bowser's Castle
         web_settings["BowlessBowsersCastleBasement"] = self.glitch_settings.bowless_bowsers_castle_basement

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/default_settings.yaml
+++ b/presets/default_settings.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_Beginner.yaml
+++ b/presets/preset_Beginner.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_Blitz.yaml
+++ b/presets/preset_Blitz.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_ExtremeShuffle.yaml
+++ b/presets/preset_ExtremeShuffle.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_Intermediate.yaml
+++ b/presets/preset_Intermediate.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_OpenWorld.yaml
+++ b/presets/preset_OpenWorld.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_StandardRaceS0.yaml
+++ b/presets/preset_StandardRaceS0.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -257,6 +257,7 @@ ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
 SewerBlocksWithoutUltraBoots                    : false
+Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false
 BlocksToShiverCityWithKooperShellItemThrow      : false
 SewerYellowBlockWithUltraBoots                  : false

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -297,6 +297,7 @@ ParakarrylessSecondSandRoomNormalBoots          : false
 ParakarrylessSuperHammerRoomUltraBoots          : false
 ParakarrylessSuperHammerRoomNormalBoots         : false
 RuinsLocksSkipClippy                            : false
+RuinsStoneSkip                                  : false
 
 ForeverForestBackwards                          : false
 

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -347,6 +347,7 @@ UltraHammerSkipSushie                           : false
 Flarakarry                                      : false
 ParakarrylessFlarakarryLaki                     : false
 VolcanoSushieGlitch                             : false
+VolcanoSushieGlitchGoombario                    : false
 
 EarlyLakiLZS                                    : false
 EarlyLakiBombettePush                           : false

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -332,6 +332,7 @@ ParakarrylessBlueBlockCityGap                   : false
 BlueSwitchSkipLaki                              : false
 BlueSwitchSkipUltraBoots                        : false
 RedBarricadeSkip                                : false
+WattlessDarkRoom                                : false
 HammerlessBlueStationLaki                       : false
 HammerlessPinkStationLaki                       : false
 

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -256,6 +256,7 @@ ClippyBootsStoneBlockSkip                       : false
 ClippyBootsMetalBlockSkip                       : false
 IslandPipeBlooperSkip                           : false
 ParakarrylessSewerStarPiece                     : false
+ClippySewersUpgradeBlock                        : false
 SewerBlocksWithoutUltraBoots                    : false
 Chapter7BridgeWithSuperBoots                    : false
 FirstBlockToShiverCityWithoutSuperBoots         : false

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -326,6 +326,7 @@ GourmetGuySkipJump                              : false
 GourmetGuySkipLaki                              : false
 GourmetGuySkipParakarry                         : false
 BowlessGreenStation                             : false
+ClippyGreenStationCoinBlock                     : false
 KooperlessRedStationShootingStar                : false
 GearlessRedStationShootingStar                  : false
 ParakarrylessBlueBlockCityGap                   : false

--- a/presets/preset_StandardRaceS1.yaml
+++ b/presets/preset_StandardRaceS1.yaml
@@ -377,6 +377,7 @@ SushielessWarehouseKeyBombette                  : false
 SushielessWarehouseKeyKooper                    : false
 
 MirrorClip                                      : false
+KooperPuzzleSkip                                : false
 
 BowlessBowsersCastleBasement                    : false
 FastFloodRoomKooper                             : false

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -208,6 +208,8 @@ from maps.graph_edges.glitched_logic.omo_parakarryless_blue_station_star_piece i
     edges_omo_add_parakarryless_blue_station_star_piece
 from maps.graph_edges.glitched_logic.omo_bowless_green_station import \
     edges_omo_add_bowless_green_station_laki
+from maps.graph_edges.glitched_logic.omo_clippy_green_station_coin_block import \
+    edges_omo_clippy_green_station_coin_block
 from maps.graph_edges.glitched_logic.omo_kooperless_red_station_shooting_star import \
     edges_omo_add_red_station_shooting_star_parakarry
 from maps.graph_edges.glitched_logic.omo_gearless_red_station_shooting_star import \
@@ -411,7 +413,8 @@ def get_gear_location_shuffle(world_graph: dict, gear_shuffle_mode: int):
 
 def get_partner_upgrade_shuffle(
     world_graph: dict,
-    shuffle_blocks: bool
+    shuffle_blocks: bool,
+    glitch_settings: GlitchOptionSet
 ) -> (dict, list):
     """
     Returns the modified world graph itself for Partner Upgrade Shuffle,
@@ -422,6 +425,12 @@ def get_partner_upgrade_shuffle(
         shuffle_blocks,
         supers_are_yellow=True
     )
+
+    # handle upgrade block glitch logic first
+    if glitch_settings.clippy_sewers_upgrade_block:
+        edges_tik_add_partnerupgrades.extend(edges_tik_add_clippy_sewers_upgrade_block)
+    if glitch_settings.clippy_green_station_coin_block:
+        edges_omo_add_partnerupgrades.extend(edges_omo_clippy_green_station_coin_block)
 
     edges_partner_upgrade = []
     edges_partner_upgrade.extend(edges_arn_add_partnerupgrades)
@@ -629,8 +638,6 @@ def get_glitched_logic(
         all_new_edges.extend(edges_tik_add_island_pipe_blooper_skip)
     if glitch_settings.parakarryless_sewer_star_piece:
         all_new_edges.extend(edges_tik_add_parakarryless_sewer_star_piece)
-    if glitch_settings.clippy_sewers_upgrade_block:
-        all_new_edges.extend(edges_tik_add_clippy_sewers_upgrade_block)
     if glitch_settings.sewer_blocks_without_ultra_boots:
         all_new_edges.extend(edges_tik_add_sewer_blocks_without_ultra_boots)
     if glitch_settings.chapter_7_bridge_with_super_boots:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -218,6 +218,8 @@ from maps.graph_edges.glitched_logic.omo_blue_switch_skip import \
     edges_omo_add_blue_switch_skip_laki, edges_omo_add_blue_switch_skip_ultra_boots
 from maps.graph_edges.glitched_logic.omo_red_barricade_skip import \
     edges_omo_add_red_barricade_skip
+from maps.graph_edges.glitched_logic.omo_wattless_dark_room import \
+    edges_omo_add_wattless_dark_room
 from maps.graph_edges.glitched_logic.omo_hammerless_blue_station import \
     edges_omo_add_hammerless_blue_station_laki
 from maps.graph_edges.glitched_logic.omo_hammerless_pink_station import \
@@ -779,6 +781,8 @@ def get_glitched_logic(
         all_new_edges.extend(edges_omo_add_blue_switch_skip_ultra_boots)
     if glitch_settings.red_barricade_skip:
         all_new_edges.extend(edges_omo_add_red_barricade_skip)
+    if glitch_settings.wattless_dark_room:
+        all_new_edges.extend(edges_omo_add_wattless_dark_room)
     if glitch_settings.hammerless_blue_station_laki:
         all_new_edges.extend(edges_omo_add_hammerless_blue_station_laki)
     if glitch_settings.hammerless_pink_station_laki:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -277,6 +277,8 @@ from maps.graph_edges.glitched_logic.sam_sushieless_warehouse_key import \
 # Glitched Logic - Crystal Palace
 from maps.graph_edges.glitched_logic.pra_mirror_clip import \
     edges_pra_add_mirror_clip_laki
+from maps.graph_edges.glitch_logic.pra_kooper_puzzle_skip import \
+    edges_pra_add_kooper_puzzle_skip
 
 # Glitched Logic - Bowser's Castle
 from maps.graph_edges.glitched_logic.kpa_bowless_bowsers_castle_basement import \
@@ -867,6 +869,8 @@ def get_glitched_logic(
     # Crystal Palace
     if glitch_settings.mirror_clip:
         all_new_edges.extend(edges_pra_add_mirror_clip_laki)
+    if glitch_settings.mirror_clip:
+        all_new_edges.extned(edges_pra_add_kooper_puzzle_skip)
 
     # Bowser's Castle
     if bowsers_castle_mode == BowserCastleMode.VANILLA:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -165,6 +165,8 @@ from maps.graph_edges.glitched_logic.isk_parakarryless_super_hammer_room import 
     edges_isk_add_parakarryless_super_hammer_room_normal_boots, edges_isk_add_parakarryless_super_hammer_room_ultra_boots
 from maps.graph_edges.glitched_logic.isk_ruins_locks_skip import \
     edges_isk_add_ruins_locks_skip_clippy
+from maps.graph_edges.glitched_logic.isk_ruins_stone_skip import \
+    edges_pra_add_ruins_stone_skip
 
 # Glitched Logic - Forever Forest
 from maps.graph_edges.glitched_logic.mim_forever_forest_backwards import \
@@ -707,6 +709,8 @@ def get_glitched_logic(
         all_new_edges.extend(edges_isk_add_ruins_key_laki_jump)
     if glitch_settings.ruins_locks_skip_clippy:
         all_new_edges.extend(edges_isk_add_ruins_locks_skip_clippy)
+    if glitch_settings.ruins_stone_skip:
+        all_new_edges.extend(edges_pra_add_ruins_stone_skip)
 
     # Forever Forest
     if glitch_settings.forever_forest_backwards:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -94,6 +94,8 @@ from maps.graph_edges.glitched_logic.tik_island_pipe_blooper_skip import \
     edges_tik_add_island_pipe_blooper_skip
 from maps.graph_edges.glitched_logic.tik_parakarryless_sewer_star_piece import \
     edges_tik_add_parakarryless_sewer_star_piece
+from maps.graph_edges.glitch_logic.tik_clippy_sewers_upgrade_block import \
+    edges_tik_add_clippy_sewers_upgrade_block
 from maps.graph_edges.glitched_logic.tik_sewer_blocks_without_ultra_boots import \
     edges_tik_add_sewer_blocks_without_ultra_boots
 from maps.graph_edges.glitched_logic.tik_chapter_7_bridge_with_super_boots import \
@@ -621,6 +623,8 @@ def get_glitched_logic(
         all_new_edges.extend(edges_tik_add_island_pipe_blooper_skip)
     if glitch_settings.parakarryless_sewer_star_piece:
         all_new_edges.extend(edges_tik_add_parakarryless_sewer_star_piece)
+    if glitch_settings.clippy_sewers_upgrade_block:
+        all_new_edges.extend(edges_tik_add_clippy_sewers_upgrade_block)
     if glitch_settings.sewer_blocks_without_ultra_boots:
         all_new_edges.extend(edges_tik_add_sewer_blocks_without_ultra_boots)
     if glitch_settings.chapter_7_bridge_with_super_boots:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -94,12 +94,12 @@ from maps.graph_edges.glitched_logic.tik_island_pipe_blooper_skip import \
     edges_tik_add_island_pipe_blooper_skip
 from maps.graph_edges.glitched_logic.tik_parakarryless_sewer_star_piece import \
     edges_tik_add_parakarryless_sewer_star_piece
-from maps.graph_edges.glitch_logic.tik_clippy_sewers_upgrade_block import \
+from maps.graph_edges.glitched_logic.tik_clippy_sewers_upgrade_block import \
     edges_tik_add_clippy_sewers_upgrade_block
 from maps.graph_edges.glitched_logic.tik_sewer_blocks_without_ultra_boots import \
     edges_tik_add_sewer_blocks_without_ultra_boots
 from maps.graph_edges.glitched_logic.tik_chapter_7_bridge_with_super_boots import \
-    edges_tik_add_blocks_to_shiver_city_super_boots
+    edges_tik_add_chapter_7_bridge_with_super_boots
 from maps.graph_edges.glitched_logic.tik_clippy_boots import \
     edges_tik_add_clippy_boots_metal_block_skip, edges_tik_add_clippy_boots_stone_block_skip
 from maps.graph_edges.glitched_logic.tik_first_block_to_shiver_city_without_super_boots import \
@@ -281,7 +281,7 @@ from maps.graph_edges.glitched_logic.sam_sushieless_warehouse_key import \
 # Glitched Logic - Crystal Palace
 from maps.graph_edges.glitched_logic.pra_mirror_clip import \
     edges_pra_add_mirror_clip_laki
-from maps.graph_edges.glitch_logic.pra_kooper_puzzle_skip import \
+from maps.graph_edges.glitched_logic.pra_kooper_puzzle_skip import \
     edges_pra_add_kooper_puzzle_skip
 
 # Glitched Logic - Bowser's Castle

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -223,7 +223,8 @@ from maps.graph_edges.glitched_logic.jan_raph_skip_english import \
 from maps.graph_edges.glitched_logic.jan_raph_skip_parakarry import \
     edges_jan_add_raph_skip_parakarry
 from maps.graph_edges.glitched_logic.jan_kzn_ch5_sushie_glitch import \
-    edges_jan_kzn_add_ch5_sushie_glitch, edges_kzn_add_volcano_sushie_glitch
+    edges_jan_kzn_add_ch5_sushie_glitch, edges_kzn_add_volcano_sushie_glitch, \
+    edges_kzn_add_volcano_sushie_glitch_superboots, edges_kzn_add_volcano_sushie_glitch_goombario
 from maps.graph_edges.glitched_logic.jan_sushieless_jungle_starpiece_and_letter import \
     edges_jan_add_sushieless_jungle_starpiece_and_letter_lzs
 from maps.graph_edges.glitched_logic.jan_jumpless_deep_jungle import \
@@ -798,7 +799,11 @@ def get_glitched_logic(
         all_new_edges.extend(edges_kzn_add_flarakarry_parakarry)
     if glitch_settings.parakarryless_flarakarry_laki:
         all_new_edges.extend(edges_kzn_add_flarakarry_laki)
-    if glitch_settings.volcano_sushie_glitch:
+    if glitch_settings.volcano_sushie_glitch_superboots: # super boots save block storage
+        all_new_edges.extend(edges_kzn_add_volcano_sushie_glitch_superboots)
+    if glitch_settings.volcano_sushie_glitch_goombario: # tattle save block storage
+        all_new_edges.extend(edges_kzn_add_volcano_sushie_glitch_goombario)
+    if glitch_settings.volcano_sushie_glitch_superboots or glitch_settings.volcano_sushie_glitch_goombario:
         all_new_edges.extend(edges_kzn_add_volcano_sushie_glitch)
 
     # Flower Fields

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -96,6 +96,8 @@ from maps.graph_edges.glitched_logic.tik_parakarryless_sewer_star_piece import \
     edges_tik_add_parakarryless_sewer_star_piece
 from maps.graph_edges.glitched_logic.tik_sewer_blocks_without_ultra_boots import \
     edges_tik_add_sewer_blocks_without_ultra_boots
+from maps.graph_edges.glitched_logic.tik_chapter_7_bridge_with_super_boots import \
+    edges_tik_add_blocks_to_shiver_city_super_boots
 from maps.graph_edges.glitched_logic.tik_clippy_boots import \
     edges_tik_add_clippy_boots_metal_block_skip, edges_tik_add_clippy_boots_stone_block_skip
 from maps.graph_edges.glitched_logic.tik_first_block_to_shiver_city_without_super_boots import \
@@ -621,6 +623,8 @@ def get_glitched_logic(
         all_new_edges.extend(edges_tik_add_parakarryless_sewer_star_piece)
     if glitch_settings.sewer_blocks_without_ultra_boots:
         all_new_edges.extend(edges_tik_add_sewer_blocks_without_ultra_boots)
+    if glitch_settings.chapter_7_bridge_with_super_boots:
+        all_new_edges.extend(edges_tik_add_chapter_7_bridge_with_super_boots)
     if glitch_settings.first_block_to_shiver_city_without_super_boots:
         all_new_edges.extend(edges_tik_add_first_block_to_shiver_city_witout_super_boots)
     if glitch_settings.blocks_to_shiver_city_kooper_shell_item_throw:

--- a/rando_modules/modify_entrances.py
+++ b/rando_modules/modify_entrances.py
@@ -166,7 +166,7 @@ from maps.graph_edges.glitched_logic.isk_parakarryless_super_hammer_room import 
 from maps.graph_edges.glitched_logic.isk_ruins_locks_skip import \
     edges_isk_add_ruins_locks_skip_clippy
 from maps.graph_edges.glitched_logic.isk_ruins_stone_skip import \
-    edges_pra_add_ruins_stone_skip
+    edges_isk_add_ruins_stone_skip
 
 # Glitched Logic - Forever Forest
 from maps.graph_edges.glitched_logic.mim_forever_forest_backwards import \
@@ -710,7 +710,7 @@ def get_glitched_logic(
     if glitch_settings.ruins_locks_skip_clippy:
         all_new_edges.extend(edges_isk_add_ruins_locks_skip_clippy)
     if glitch_settings.ruins_stone_skip:
-        all_new_edges.extend(edges_pra_add_ruins_stone_skip)
+        all_new_edges.extend(edges_isk_add_ruins_stone_skip)
 
     # Forever Forest
     if glitch_settings.forever_forest_backwards:
@@ -873,8 +873,8 @@ def get_glitched_logic(
     # Crystal Palace
     if glitch_settings.mirror_clip:
         all_new_edges.extend(edges_pra_add_mirror_clip_laki)
-    if glitch_settings.mirror_clip:
-        all_new_edges.extned(edges_pra_add_kooper_puzzle_skip)
+    if glitch_settings.kooper_puzzle_skip:
+        all_new_edges.extend(edges_pra_add_kooper_puzzle_skip)
 
     # Bowser's Castle
     if bowsers_castle_mode == BowserCastleMode.VANILLA:

--- a/random_seed.py
+++ b/random_seed.py
@@ -142,7 +142,8 @@ class RandomSeed:
                 if self.rando_settings.partner_upgrade_shuffle != PartnerUpgradeShuffle.OFF:
                     modified_world_graph, self.placed_blocks = get_partner_upgrade_shuffle(
                         modified_world_graph,
-                        self.rando_settings.shuffle_blocks
+                        self.rando_settings.shuffle_blocks,
+                        self.rando_settings.glitch_settings
                     )
 
                 # Cull unneeded data from world graph if access to maps was


### PR DESCRIPTION
Implementing a handful of glitches that do not currently exist in the glitch logic list.

* Volcano Sushie Glitch (Goombario + Normal Boots)
* Chapter 7 bridge hidden blocks can be hit with Super Boots frame perfectly
* Clippy in the sewers to get at the upgrade block behind metal blocks
* Dry Dry Ruins Stone Skip
* Kooper Puzzle Skip for Crystal Palace
* New Methods for Prologue Repel Gel that have been found
* Enter General Guy fight with Laki instead of Watt