### PR TITLE
Fixed Gusty Gulch logic error (step climbing not in logic for first small ledge

### DIFF
--- a/maps/graph_edges/base_graph/edges_arn.py
+++ b/maps/graph_edges/base_graph/edges_arn.py
@@ -8,10 +8,10 @@ edges_arn = [
     {"from": {"map": "ARN_02", "id": 1}, "to": {"map": "ARN_02", "id": 0}, "reqs": []}, #? Wasteland Ascent 1 Exit East -> Wasteland Ascent 1 Exit West
 
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemA"},   "reqs": [["Kooper"]]}, #* Wasteland Ascent 1 Exit West -> ItemA (DizzyDial)
-    {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemB"},   "reqs": []}, #* Wasteland Ascent 1 Exit West -> ItemB (Letter07)
+    {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemB"},   "reqs": [["can_climb_steps"]]}, #* Wasteland Ascent 1 Exit West -> ItemB (Letter07)
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "YBlockA"}, "reqs": [["can_hit_floating_blocks"]]}, #* Wasteland Ascent 1 Exit West -> YBlockA (Coin)
-    {"from": {"map": "ARN_02", "id": "YBlockA"}, "to": {"map": "ARN_02", "id": "YBlockB"}, "reqs": []}, #+ SHARED REQUIREMENTS -> YBlockB (Coin)
-    {"from": {"map": "ARN_02", "id": "YBlockA"}, "to": {"map": "ARN_02", "id": "YBlockC"}, "reqs": []}, #+ SHARED REQUIREMENTS -> YBlockC (RepelGel)
+    {"from": {"map": "ARN_02", "id": 0}, "to": {"map": "ARN_02", "id": "YBlockB"}, "reqs": [["can_climb_steps"], ["can_hit_floating_blocks"]]}, #+ Wasteland Ascent 1 Exit West -> YBlockB (Coin)
+    {"from": {"map": "ARN_02", "id": "YBlockB"}, "to": {"map": "ARN_02", "id": "YBlockC"}, "reqs": []}, #+ SHARED REQUIREMENTS -> YBlockC (RepelGel)
 
     # ARN_03 Ghost Town 1
     {"from": {"map": "ARN_03", "id": 0}, "to": {"map": "ARN_07", "id": 1}, "reqs": []}, # Ghost Town 1 Exit West -> Windmill Exterior Exit East

--- a/maps/graph_edges/base_graph/edges_arn.py
+++ b/maps/graph_edges/base_graph/edges_arn.py
@@ -10,7 +10,7 @@ edges_arn = [
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemA"},   "reqs": [["Kooper"]]}, #* Wasteland Ascent 1 Exit West -> ItemA (DizzyDial)
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "ItemB"},   "reqs": [["can_climb_steps"]]}, #* Wasteland Ascent 1 Exit West -> ItemB (Letter07)
     {"from": {"map": "ARN_02", "id": 0},         "to": {"map": "ARN_02", "id": "YBlockA"}, "reqs": [["can_hit_floating_blocks"]]}, #* Wasteland Ascent 1 Exit West -> YBlockA (Coin)
-    {"from": {"map": "ARN_02", "id": 0}, "to": {"map": "ARN_02", "id": "YBlockB"}, "reqs": [["can_climb_steps"], ["can_hit_floating_blocks"]]}, #+ Wasteland Ascent 1 Exit West -> YBlockB (Coin)
+    {"from": {"map": "ARN_02", "id": 0}, "to": {"map": "ARN_02", "id": "YBlockB"}, "reqs": [["can_climb_steps"], ["can_hit_floating_blocks"]]}, #* Wasteland Ascent 1 Exit West -> YBlockB (Coin)
     {"from": {"map": "ARN_02", "id": "YBlockB"}, "to": {"map": "ARN_02", "id": "YBlockC"}, "reqs": []}, #+ SHARED REQUIREMENTS -> YBlockC (RepelGel)
 
     # ARN_03 Ghost Town 1


### PR DESCRIPTION
As reported in discord by MarioMan here. https://discord.com/channels/958691533270433793/958766560493834290/1269138678220066889

As he says, this only affects glitched logic seeds (at least pre-entrance shuffle) as you normally need Boots to access Gusty Gulch.

Seed with issue is here https://pm64randomizer.com/seed?id=551143007

The ledge in question:
![image](https://github.com/user-attachments/assets/2c9d3126-897b-4199-aa86-1f6be713aa42)
